### PR TITLE
Remove dependent package installation.

### DIFF
--- a/CLI/Makefile
+++ b/CLI/Makefile
@@ -20,14 +20,13 @@ SHELL = /bin/bash
 .ONESHELL:
 .SHELLFLAGS += -e
 
-CLIDEPS ?= packages
 SUBDIRS := clitree renderer klish 
 export SONIC_CLI_ROOT=$(TOPDIR)/build
 TGT_DIR := $(SONIC_CLI_ROOT)/target
 
 .PHONY: clean
 
-all: $(CLIDEPS)
+all:
 	for dir in $(SUBDIRS); do \
     	$(MAKE) -C $$dir -f Makefile $@; \
 	done
@@ -39,12 +38,3 @@ clean:
 	make --directory=klish clean
 	rm -rf $(TOPDIR)/build/cli
 	rm -rf $(TGT_DIR)
-
-packages:
-	if ! dpkg -l | grep autoconf -c >>/dev/null; then sudo apt-get install autoconf; fi
-	if ! dpkg -l | grep m4 -c >>/dev/null; then sudo apt-get install m4; fi
-	if ! dpkg -l | grep libxml2-utils -c >>/dev/null; then sudo apt-get install libxml2-utils; fi
-	if ! dpkg -l | grep xsltproc -c >>/dev/null; then sudo apt-get install xsltproc; fi
-	if ! dpkg -l | grep python-lxml -c >>/dev/null; then sudo apt-get install python-lxml; fi
-	if ! dpkg -l | grep libexpat1-dev -c >>/dev/null; then sudo apt-get install libexpat1-dev; fi
-


### PR DESCRIPTION
Signed-off-by: Joyas Joseph <joyas_joseph@dell.com>

**- Why I did it**
Code cleanup.

While analyzing a build failure for sonic-mgmt-framework, it was observed that package installations are happening during the build stage.
```
05:30:15  make -C src/CLI
05:30:15  make[3]: Entering directory '/sonic/src/sonic-mgmt-framework/src/CLI'
05:30:15  if ! dpkg -l | grep autoconf -c >>/dev/null; then sudo apt-get install autoconf; fi
05:30:15  if ! dpkg -l | grep m4 -c >>/dev/null; then sudo apt-get install m4; fi
05:30:15  if ! dpkg -l | grep libxml2-utils -c >>/dev/null; then sudo apt-get install libxml2-utils; fi
05:30:15  if ! dpkg -l | grep xsltproc -c >>/dev/null; then sudo apt-get install xsltproc; fi
05:30:15  if ! dpkg -l | grep python-lxml -c >>/dev/null; then sudo apt-get install python-lxml; fi
05:30:15  if ! dpkg -l | grep libexpat1-dev -c >>/dev/null; then sudo apt-get install libexpat1-dev; fi
05:30:15  Reading package lists...
05:30:15  Building dependency tree...
05:30:15  Reading state information...
05:30:15  You might want to run 'apt --fix-broken install' to correct these.
05:30:15  The following packages have unmet dependencies:
05:30:15   libnl-route-3-200 : Depends: libnl-3-200 (= 3.4.0-1) but 3.5.0-1 is to be installed
05:30:15   libnl-route-3-dev : Depends: libnl-3-dev (= 3.4.0-1) but 3.5.0-1 is to be installed
05:30:15  E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```
The required packages are now installed in the sonic-slave docker.

**- How I did it**
Code change.

**- How to verify it**
Build sonic-mgmt-framework package and docker

**- Description for the changelog**
Remove dependent package installation from build stage.


**- A picture of a cute animal (not mandatory but encouraged)**
