### PR TITLE
delete enable element without prefix.

### DIFF
--- a/CLI/clitree/scripts/klish_ins_def_cmd.py
+++ b/CLI/clitree/scripts/klish_ins_def_cmd.py
@@ -117,7 +117,7 @@ def update_view_tag(root, viewlist, filename, out_dirpath):
                 element_inst.insert(0,end_element)
                 element_inst.insert(0,exit_element)
                 element_inst.insert(0,inherit_enable_element)
-                element_inst.insert(0,inherit_enable_element_without_prefix)
+#                element_inst.insert(0,inherit_enable_element_without_prefix)
                 element_inst.insert(0,comment_element)
 
                 file_modified = True


### PR DESCRIPTION
Delete enable element without prefix.A new view or other view can use enable-view's commands without prefix,this is not a common scenario，so by default, do not insert this element.