### PR TITLE
Correct shell-ism in patchmake.sh

### DIFF
--- a/CLI/klish/patches/scripts/patchmake.sh
+++ b/CLI/klish/patches/scripts/patchmake.sh
@@ -145,7 +145,7 @@ mkdir -p $TMP_PATH
 
 #Handling of skipping patch
 if [ ! "$SKIP_PATCH" == "yes" ]; then
-	if [ "$FORCE_PATCH" == "yes" || ! -f "$TMP_PATH/$TMP_SRC_PATH2/##patched##" ]; then
+	if [ "$FORCE_PATCH" == "yes" ] || [ ! -f "$TMP_PATH/$TMP_SRC_PATH2/##patched##" ]; then
 
 		#Copying the actual source files into the temporary directory
 		cp -r $TMP_SRC_PATH/$TMP_SRC_PATH2 $TMP_PATH


### PR DESCRIPTION
Current syntax is not valid for e.g. Bullseye where the shell is more strict.