### PR TITLE
Update klish_insert_pipe.py for Python3

### DIFF
--- a/CLI/clitree/scripts/klish_insert_pipe.py
+++ b/CLI/clitree/scripts/klish_insert_pipe.py
@@ -166,7 +166,7 @@ def insert_pipe (dirpath, debug):
             print('Parsing ', fname)
         if fname.endswith(".xml", re.I):
             try:
-                temp_file = open(temp_file_name, "w")
+                temp_file = open(temp_file_name, "wb")
             except IOError as e:
                 print(e.filename, ":", e.strerror)
                 sys.exit(99)


### PR DESCRIPTION
etree requires binary data as input in newer Python3. Make sure the temp file is opened as a byte oriented file object.