### PR TITLE
Update rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,6 @@
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info -l$(shell pwd)/build/cli/target/.libs/:$(shell pwd)/build/cli/.libs/
+
+override_dh_strip:
+	dh_strip --dbg-package=sonic-mgmt-framework-dbg


### PR DESCRIPTION
**Why I did it**

sonic-mgmt-framework-dbg don't support debug function

**How I did it**
Modify rules file to support debug function
override_dh_strip:
	dh_strip --dbg-package=sonic-mgmt-framework-dbg