### PR TITLE
Query parameters enhancements in rest-server. 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,8 @@ stages:
         artifact: sonic-buildimage.vs
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/master'
+        patterns: |
+          target/debs/buster/libyang*.deb
       displayName: "Download sonic buildimage"
 
     - script: |

--- a/rest/server/handler.go
+++ b/rest/server/handler.go
@@ -260,6 +260,8 @@ type translibArgs struct {
 	data        []byte           // payload
 	version     translib.Version // client version
 	depth       uint             // RESTCONF depth, for Get API only
+	content     string           // RESTCONF content, for Get API only
+	fields      []string         // RESTCONF fields, for Get API only
 	deleteEmpty bool             // Delete empty entry during field delete
 }
 
@@ -304,8 +306,12 @@ func invokeTranslib(args *translibArgs, rc *RequestContext) (int, []byte, error)
 	case "GET", "HEAD":
 		req := translib.GetRequest{
 			Path:          args.path,
-			Depth:         args.depth,
 			ClientVersion: args.version,
+			QueryParams: translib.QueryParameters{
+				Depth:   args.depth,
+				Content: args.content,
+				Fields:  args.fields,
+			},
 		}
 		resp, err1 := translib.Get(req)
 		if err1 == nil {

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -561,10 +561,10 @@ func verifyParseVersion(t *testing.T, r *http.Request, expSuccess bool, expVer t
 
 func TestPanic(t *testing.T) {
 	s := newEmptyRouter()
-	s.addRoute("panic", "GET", "/panic",
+	s.addRoute("panic", "GET", "/restconf/panic",
 		func(w http.ResponseWriter, r *http.Request) { panic("testing 123") })
 	w := httptest.NewRecorder()
-	s.ServeHTTP(w, prepareRequest(t, "GET", "/panic", ""))
+	s.ServeHTTP(w, prepareRequest(t, "GET", "/restconf/panic", ""))
 	verifyResponse(t, w, 500)
 }
 

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -574,6 +574,60 @@ func TestProcessGET(t *testing.T) {
 	verifyResponseData(t, w, 200, jsonObj{"path": "/api-tests:sample", "depth": 0})
 }
 
+func TestProcessGET_query_depth(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "GET", "/api-tests:sample?depth=10", ""))
+	if restconfCapabilities.depth {
+		verifyResponseData(t, w, 200, jsonObj{"depth": 10})
+	} else {
+		verifyResponse(t, w, 400)
+	}
+}
+
+func TestProcessGET_query_depth_error(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "GET", "/api-tests:sample?depth=none", ""))
+	verifyResponse(t, w, 400)
+}
+
+func TestProcessGET_query_depth_content_field_capability_support(t *testing.T) {
+	if !restconfCapabilities.depth || !restconfCapabilities.content || !restconfCapabilities.fields {
+		t.Fatalf("depth/content/fields capability is expected to be supported in rest-server")
+	}
+}
+
+func TestProcessGET_query_content(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "GET", "/api-tests:sample?content=all", ""))
+	if restconfCapabilities.content {
+		verifyResponseData(t, w, 200, jsonObj{"content": "all"})
+	} else {
+		verifyResponse(t, w, 400)
+	}
+}
+
+func TestProcessGET_query_content_error(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "GET", "/api-tests:sample?content=getall", ""))
+	verifyResponse(t, w, 400)
+}
+
+func TestProcessGET_query_fields(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "GET", "/api-tests:sample?fields=home/name", ""))
+	if restconfCapabilities.fields {
+		verifyResponseData(t, w, 200, jsonObj{"fields": "[home/name]"})
+	} else {
+		verifyResponse(t, w, 400)
+	}
+}
+
+func TestProcessGET_query_fields_error(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "GET", "/api-tests:sample?fields=home&content=all", ""))
+	verifyResponse(t, w, 400)
+}
+
 func TestProcessGET_error(t *testing.T) {
 	w := httptest.NewRecorder()
 	Process(w, prepareRequest(t, "GET", "/api-tests:sample/error/not-found", ""))

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -744,6 +744,10 @@ func TestProcessReadError(t *testing.T) {
 }
 
 func prepareRequest(t *testing.T, method, path, data string) *http.Request {
+	if !strings.Contains(path, "/restconf/") {
+		path = "/restconf/data" + path
+	}
+
 	r := httptest.NewRequest(method, path, strings.NewReader(data))
 	rc, r := GetContext(r)
 	rc.ID = t.Name()

--- a/rest/server/restconf.go
+++ b/rest/server/restconf.go
@@ -39,7 +39,9 @@ const (
 
 // restconfCapabilities defines server capabilities
 var restconfCapabilities struct {
-	depth bool // depth query parameter
+	depth   bool // depth query parameter
+	content bool // content query parameter
+	fields  bool // fields query parameter
 }
 
 func init() {
@@ -51,6 +53,9 @@ func init() {
 	AddRoute("yanglibVersionHandler", "GET", "/restconf/yang-library-version", yanglibVersionHandler)
 
 	// RESTCONF capability handler
+	restconfCapabilities.depth = true
+	restconfCapabilities.content = true
+	restconfCapabilities.fields = true
 	AddRoute("capabilityHandler", "GET",
 		"/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities", capabilityHandler)
 	AddRoute("capabilityHandler", "GET",
@@ -111,7 +116,14 @@ func capabilityHandler(w http.ResponseWriter, r *http.Request) {
 		c.Capabilities.Capability = append(c.Capabilities.Capability,
 			"urn:ietf:params:restconf:capability:depth:1.0")
 	}
-
+	if restconfCapabilities.content {
+		c.Capabilities.Capability = append(c.Capabilities.Capability,
+			"urn:ietf:params:restconf:capability:content:1.0")
+	}
+	if restconfCapabilities.fields {
+		c.Capabilities.Capability = append(c.Capabilities.Capability,
+			"urn:ietf:params:restconf:capability:fields:1.0")
+	}
 	var data []byte
 	if strings.HasSuffix(r.URL.Path, "/capabilities") {
 		data, _ = json.Marshal(&c)

--- a/rest/server/restconf_test.go
+++ b/rest/server/restconf_test.go
@@ -165,6 +165,17 @@ func testCapability(t *testing.T, path string) {
 	if c, ok := cap.([]interface{}); !ok || len(c) == 0 {
 		log.Fatalf("Could not parse capability info: %s", w.Body.String())
 	}
+
+	var curCap []interface{}
+	curCap = append(curCap, "urn:ietf:params:restconf:capability:defaults:1.0?basic-mode=report-all",
+		"urn:ietf:params:restconf:capability:depth:1.0",
+		"urn:ietf:params:restconf:capability:content:1.0",
+		"urn:ietf:params:restconf:capability:fields:1.0")
+
+	if !reflect.DeepEqual(cap.([]interface{}), curCap) {
+		t.Fatalf("Response does not include expected capabilities \n"+
+			"expected: %v\nfound: %v", curCap, cap)
+	}
 }
 
 func TestOpsDiscovery_none(t *testing.T) {


### PR DESCRIPTION
Add support for following standard REST query-parameters for GET operation(https://datatracker.ietf.org/doc/html/rfc8040#section-4.8) :

depth : used to limit the depth of subtrees retrieved for a given GET request.
content : used to retrieve config and/or non-config descendant nodes of requested target in a GET request.
fields : used to retrieve specific subset of data nodes within the target for a GET request.

Verification done using unit tests and added new cases for above.
Unit test run results are part of pipeline test run.

Has build dependency on the below PR 
https://github.com/sonic-net/sonic-mgmt-common/pull/102
Both the PRs needs to be merged together to support the query parameters enhancement