### PR TITLE
Download only required artifacts during pipeline build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,8 @@ stages:
         artifact: sonic-buildimage.vs
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/master'
+        patterns: |
+          target/debs/buster/libyang*.deb
       displayName: "Download sonic buildimage"
 
     - script: |


### PR DESCRIPTION
Download only libyang*.deb to save space
