### PR TITLE
[fpmsyncd] Added CLI for Fpmsyncd Next Hop Table Enhancement #107

### DIFF
--- a/CLI/actioner/sonic-cli-feature.py
+++ b/CLI/actioner/sonic-cli-feature.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+###########################################################################
+#
+# Copyright (C) 2023 NIPPON TELEGRAPH AND TELEPHONE CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###########################################################################
+
+import sys
+import cli_client as cc
+import re
+
+
+def invoke(func, enable):
+    body = None
+    aa = cc.ApiClient()
+
+    feature = "nexthop_group"
+
+    if enable == "1":
+
+        keypath = cc.Path("/restconf/data/sonic-feature:sonic-feature")
+
+        body = {
+            "sonic-feature": {
+                "FEATURE": {"FEATURE_LIST": [{"name": feature, "state": "enabled"}]}
+            }
+        }
+        return aa.patch(keypath, body)
+
+    else:
+
+        keypath = cc.Path(
+            "/restconf/data/sonic-feature:sonic-feature/FEATURE/FEATURE_LIST={}".format(
+                feature
+            )
+        )
+
+        return aa.delete(keypath)
+
+
+def run(func, enable):
+    if func != "configure_sonic_nexthop_groups":
+        print("%Error: Invalid function")
+        return
+
+    try:
+        api_response = invoke(func, enable)
+    except ValueError as err_msg:
+        print(
+            "%Error: An exception occurred while attempting to execute "
+            "the requested RPC call: {}".format(err_msg)
+        )
+
+    if not api_response.ok():
+        # Print the message for a failing return code
+        print("CLI transformer error: ")
+        print("    status code: {}".format(api_response.status_code))
+        if (
+            "error" in api_response.errors()
+            and len(api_response.errors()["error"]) >= 1
+            and "error-message" in api_response.errors()["error"][0]
+        ):
+            print(
+                "    error: {}".format(
+                    api_response.errors()["error"][0]["error-message"]
+                )
+            )
+        return
+
+    print("Success")
+
+
+if __name__ == "__main__":
+    run(sys.argv[1], sys.argv[2])

--- a/CLI/clitree/cli-xml/sonic-feature.xml
+++ b/CLI/clitree/cli-xml/sonic-feature.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2023 NIPPON TELEGRAPH AND TELEPHONE CORPORATION.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<CLISH_MODULE
+  xmlns="http://www.dellemc.com/sonic/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xsi:schemaLocation="http://www.dellemc.com/sonic/XMLSchema
+  http://www.dellemc.com/sonic/XMLSchema/clish.xsd"
+  >
+  <!--=========================================================================-->
+
+  <VIEW name="configure-view">
+
+    <COMMAND name="feature" help="Configure additional feature"></COMMAND>
+    <COMMAND name="feature next-hop-group" help="Next-hop Groups feature"></COMMAND>
+    <COMMAND name="feature next-hop-group enable" help="Enable Next-hop Groups feature">
+      <ACTION>
+        python3 $SONIC_CLI_ROOT/sonic-cli-feature.py configure_sonic_nexthop_groups 1
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND name="no feature" help="Disable additional feature"></COMMAND>
+    <COMMAND name="no feature next-hop-group" help="Disable Next-hop Groups feature">
+      <ACTION>
+        python3 $SONIC_CLI_ROOT/sonic-cli-feature.py configure_sonic_nexthop_groups 0
+      </ACTION>
+    </COMMAND>
+
+  </VIEW>
+</CLISH_MODULE>


### PR DESCRIPTION
#### Why I did it
Implementing code changes for https://github.com/sonic-net/SONiC/pull/1425

#### How to verify it

##### enable/disable nexthop group feature

- Klish will call REST API to configure `feature next-hop-group enable`.
- `FEATURE|nexthop_group` will be created in `CONFIG_DB`
  - template `zebra.conf.j2` will generate `zebra.conf` with `fpm use-next-hop-groups` if `FEATURE|nexthop_group` exists in `CONFIG_DB`. Else, it will generate `zebra.conf` with `no fpm use-next-hop-groups` (default behavior)
- Do `config save` comman and write to `/etc/sonic/config_db.json`
- restart SONiC: `virsh reboot sonic-nhg`
- `/etc/frr/zebra.conf` has `fpm use-next-hop-groups` instead of `no fpm use-next-hop-groups`

##### Klish CLI for feature nexthop_group

- Enable: `sonic(config)# feature next-hop-group enable`
- Disable: `sonic(config)# no feature next-hop-group`

Enable

```sh
admin@sonic:~$ sonic-cli

sonic# configure terminal

sonic(config)#
  end        Exit to EXEC mode
  exit       Exit from current mode
  feature    Configure additional feature
  interface  Select an interface
  ip         Global IP configuration subcommands
  mclag      domain
  no         To delete / disable commands in config mode

sonic(config)# feature
  next-hop-group  Next-hop Groups feature

sonic(config)# feature next-hop-group
  enable  Enable Next-hop Groups feature

sonic(config)# feature next-hop-group enable
  <cr>
```

Disable

```sh
sonic(config)# no
  feature  Disable additional feature
  ip       Global IP configuration subcommands
  mclag    domain

sonic(config)# no feature
  next-hop-group  Disable Next-hop Groups feature

sonic(config)# no feature next-hop-group
  <cr>
```