### PR TITLE
remove tls cipher suite settings

### DIFF
--- a/rest/main/main.go
+++ b/rest/main/main.go
@@ -105,6 +105,7 @@ func main() {
 		Certificates:             prepareServerCertificate(),
 		ClientCAs:                prepareCACertificates(),
 		MinVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
 	}
 
 	// Prepare HTTPS server

--- a/rest/main/main.go
+++ b/rest/main/main.go
@@ -104,6 +104,7 @@ func main() {
 		ClientAuth:               getTLSClientAuthType(),
 		Certificates:             prepareServerCertificate(),
 		ClientCAs:                prepareCACertificates(),
+		MinVersion:               tls.VersionTLS12,
 	}
 
 	// Prepare HTTPS server

--- a/rest/main/main.go
+++ b/rest/main/main.go
@@ -104,9 +104,6 @@ func main() {
 		ClientAuth:               getTLSClientAuthType(),
 		Certificates:             prepareServerCertificate(),
 		ClientCAs:                prepareCACertificates(),
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		CipherSuites:             getPreferredCipherSuites(),
 	}
 
 	// Prepare HTTPS server
@@ -196,17 +193,6 @@ func getTLSClientAuthType() tls.ClientAuthType {
 		glog.Fatalf("Invalid '--client_auth' value '%s'. "+
 			"Expecting one of 'none', 'cert' or 'user'", clientAuth)
 		return tls.RequireAndVerifyClientCert // dummy
-	}
-}
-
-func getPreferredCipherSuites() []uint16 {
-	return []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	}
 }
 


### PR DESCRIPTION
MSFT ADO: 24943795

To make TLS 1.3 compliant in sonic, it is not recommended to set cipher suite objects in Tls.Config struct. Refer to ADO for TLS 1.3 requirements.

Verified by building new sonic image, compare new syslog with old one.

