### PR TITLE
OpenAPI 3.0 upgrade, swagger tool chain update

### DIFF
--- a/CLI/klish/clish_start
+++ b/CLI/klish/clish_start
@@ -7,7 +7,7 @@ then
  export SYSTEM_NAME="${HOSTNAME%%.*}"
 fi
 
-export PYTHONPATH=/usr/sbin/cli:/usr/sbin/cli/scripts:/usr/sbin/:/usr/sbin/lib/swagger_client_py
+export PYTHONPATH=/usr/sbin/cli:/usr/sbin/cli/scripts:/usr/sbin
 export RENDERER_TEMPLATE_PATH=$SONIC_CLI_ROOT/render-templates
 export CLISH_PATH=$SONIC_CLI_ROOT/command-tree
 export LD_LIBRARY_PATH=/usr/local/lib:$SONIC_CLI_ROOT/.libs:$LD_LIBRARY_PATH

--- a/debian/sonic-mgmt-framework.install
+++ b/debian/sonic-mgmt-framework.install
@@ -1,5 +1,4 @@
 build/rest_server/rest_server       usr/sbin
 build/rest_server/generate_cert     usr/sbin
 build/rest_server/dist/ui           etc/rest_server
-build/swagger_client_py/*_client    usr/sbin/lib/swagger_client_py
 build/cli                           usr/sbin

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
+github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/rest/main/main.go
+++ b/rest/main/main.go
@@ -34,7 +34,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Azure/sonic-mgmt-framework/build/rest_server/dist/swagger"
+	"github.com/Azure/sonic-mgmt-framework/build/rest_server/dist/openapi"
 	"github.com/Azure/sonic-mgmt-framework/rest/server"
 	"github.com/golang/glog"
 	"github.com/pkg/profile"
@@ -85,7 +85,7 @@ func main() {
 		prof.Stop()
 	}()
 
-	swagger.Load()
+	openapi.Load()
 
 	rtrConfig := server.RouterConfig{}
 	if clientAuth == "user" {

--- a/tools/codegen/go-server/src/openapi/routes.go
+++ b/tools/codegen/go-server/src/openapi/routes.go
@@ -1,0 +1,24 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package openapi
+
+// Load function loads OpenAPI generated routes into REST server.
+func Load() {
+}

--- a/tools/codegen/go-server/templates-yang/controllers-api.j2
+++ b/tools/codegen/go-server/templates-yang/controllers-api.j2
@@ -1,0 +1,41 @@
+
+package openapi
+
+import (
+	"net/http"
+
+	"github.com/Azure/sonic-mgmt-framework/rest/server"
+)
+
+{% for operationId in OpIds %}
+{% set path = OpIdDict[operationId]["path"] %}
+{% set pathEntry = OpIdDict[operationId]["obj"] %}
+{% set method = OpIdDict[operationId]["method"] %}
+func {{ operationId }}(w http.ResponseWriter, r *http.Request) {
+    rc, r := server.GetContext(r)
+    rc.Name = "{{ operationId }}"
+	{% if method in ["post", "put", "patch"] and "requestBody" in pathEntry %}
+	{% for consume in pathEntry["requestBody"]["content"].keys() %}
+    rc.Consumes.Add("{{ consume }}")
+	{% endfor %}
+	{% endif %}
+	{% set content = dict() %}
+	{% if method == "get" %}
+	{% set content = pathEntry["responses"]["200"]["content"] %}
+	{% endif %}
+	{% if 'x-rpc' in pathEntry and 'content' in pathEntry["responses"]["204"] %}
+	{% set content = pathEntry["responses"]["204"]["content"] %}
+	{% endif %}
+	{% for produce in content.keys() %}
+    rc.Produces.Add("{{ produce }}")
+	{% endfor %}
+	{% if 'x-params' in pathEntry.keys() %}
+	{% set varMappings = pathEntry['x-params']['varMapping'] %}
+    rc.PMap = server.NameMap{ {% for varMapping in varMappings %}"{{ varMapping['uriName'] }}":"{{ varMapping['yangName'] }}", {% endfor %} }
+	{% endif %}
+	server.Process(w, r)
+}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}

--- a/tools/codegen/go-server/templates-yang/routers.j2
+++ b/tools/codegen/go-server/templates-yang/routers.j2
@@ -1,0 +1,22 @@
+
+package openapi
+
+import (
+	"github.com/Azure/sonic-mgmt-framework/rest/server"
+)
+
+func init() {
+	
+{% for operationId in OpIds %}
+{% set path = OpIdDict[operationId]["path"] %}
+{% set pathEntry = OpIdDict[operationId]["obj"] %}
+{% set method = OpIdDict[operationId]["method"] %}
+	server.AddRoute(
+		"{{ operationId }}",
+		"{{ method|capitalize }}",
+		"{{ path }}",
+		{{ operationId }},
+	)
+	
+{% endfor %}
+}

--- a/tools/openapi_tests/Makefile
+++ b/tools/openapi_tests/Makefile
@@ -1,0 +1,29 @@
+.PHONY: all test-rpc test-data-nodes
+
+TOPDIR             := ../..
+PYANG_PLUGINS_DIR  := $(TOPDIR)/tools/pyang/pyang_plugins
+PYANG ?= pyang
+
+all: test-rpc test-data-nodes test-complex-model test-complex-model-no-oneof
+
+# This will cover RPC statements with only input, only output and with
+# both input and output
+test-rpc:
+	$(PYANG) -f swaggerapi --plugindir $(PYANG_PLUGINS_DIR) test-rpc.yang | diff test-rpc.yang.expect -
+
+# This will cover container, list, leaf and leaf-lists with both
+# simple and nested hierarchies.
+# Also this will cover data type testing such as leafref, enum and string with pattern
+# simple string, integer types, leaf with default values, mandatory statements etc.
+test-data-nodes:
+	$(PYANG) -f swaggerapi --plugindir $(PYANG_PLUGINS_DIR) test-data-nodes.yang | diff test-data-nodes.yang.expect -
+
+# This will cover some complex YANGs, with many nested hierarchies
+# Also with choice-case statements, Union data types, range with min,max etc
+# Test with one-oneof
+test-complex-model:
+	$(PYANG) -f swaggerapi --plugindir $(PYANG_PLUGINS_DIR) --with-oneof ietf-snmp.yang ietf-snmp-community.yang | diff ietf-snmp.yang.expect -
+
+# Test without one-oneof
+test-complex-model-no-oneof:
+	$(PYANG) -f swaggerapi --plugindir $(PYANG_PLUGINS_DIR) ietf-snmp.yang ietf-snmp-community.yang | diff ietf-snmp.no-oneof.yang.expect -

--- a/tools/openapi_tests/ietf-inet-types.yang
+++ b/tools/openapi_tests/ietf-inet-types.yang
@@ -1,0 +1,457 @@
+module ietf-inet-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+  prefix "inet";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of types related to protocol fields ***/
+
+  typedef ip-version {
+    type enumeration {
+      enum unknown {
+        value "0";
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum ipv4 {
+        value "1";
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum ipv6 {
+        value "2";
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+     "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+    reference
+     "RFC 3289: Management Information Base for the Differentiated
+                Services Architecture
+      RFC 2474: Definition of the Differentiated Services Field
+                (DS Field) in the IPv4 and IPv6 Headers
+      RFC 2780: IANA Allocation Guidelines For Values In
+                the Internet Protocol and Related Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+     "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+    reference
+     "RFC 3595: Textual Conventions for IPv6 Flow Label
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16 {
+      range "0..65535";
+    }
+    description
+     "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+    reference
+     "RFC  768: User Datagram Protocol
+      RFC  793: Transmission Control Protocol
+      RFC 4960: Stream Control Transmission Protocol
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  /*** collection of types related to autonomous systems ***/
+
+  typedef as-number {
+    type uint32;
+    description
+     "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+    reference
+     "RFC 1930: Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+      RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+      RFC 4001: Textual Conventions for Internet Network Addresses
+      RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+                Number Space";
+  }
+
+  /*** collection of types related to IP addresses and hostnames ***/
+
+  typedef ip-address {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv6-address;
+    }
+    description
+     "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+      + '(%[\p{N}\p{L}]+)?';
+    }
+    description
+      "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+  }
+
+  typedef ipv6-address {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(%[\p{N}\p{L}]+)?';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(%.+)?';
+    }
+    description
+     "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-address-no-zone {
+    type union {
+      type inet:ipv4-address-no-zone;
+      type inet:ipv6-address-no-zone;
+    }
+    description
+     "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address-no-zone {
+    type inet:ipv4-address {
+      pattern '[0-9\.]*';
+    }
+    description
+      "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+  }
+
+  typedef ipv6-address-no-zone {
+    type inet:ipv6-address {
+      pattern '[0-9a-fA-F:\.]*';
+    }
+    description
+      "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type inet:ipv4-prefix;
+      type inet:ipv6-prefix;
+    }
+    description
+     "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+    }
+    description
+     "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(/.+)';
+    }
+    description
+     "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+    reference
+     "RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  /*** collection of domain name and URI types ***/
+
+  typedef domain-name {
+    type string {
+      length "1..253";
+      pattern
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'
+      + '|\.';
+    }
+    description
+     "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+    reference
+     "RFC  952: DoD Internet Host Table Specification
+      RFC 1034: Domain Names - Concepts and Facilities
+      RFC 1123: Requirements for Internet Hosts -- Application
+                and Support
+      RFC 2782: A DNS RR for specifying the location of services
+                (DNS SRV)
+      RFC 5890: Internationalized Domain Names in Applications
+                (IDNA): Definitions and Document Framework";
+  }
+
+  typedef host {
+    type union {
+      type inet:ip-address;
+      type inet:domain-name;
+    }
+    description
+     "The host type represents either an IP address or a DNS
+      domain name.";
+  }
+
+  typedef uri {
+    type string;
+    description
+     "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+    reference
+     "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+                Group: Uniform Resource Identifiers (URIs), URLs,
+                and Uniform Resource Names (URNs): Clarifications
+                and Recommendations
+      RFC 5017: MIB Textual Conventions for Uniform Resource
+                Identifiers (URIs)";
+  }
+
+}

--- a/tools/openapi_tests/ietf-snmp-common.yang
+++ b/tools/openapi_tests/ietf-snmp-common.yang
@@ -1,0 +1,196 @@
+submodule ietf-snmp-common {
+
+  belongs-to ietf-snmp {
+    prefix snmp;
+  }
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+    "This submodule contains a collection of common YANG definitions
+     for configuring SNMP engines.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7407; see
+     the RFC itself for full legal notices.";
+
+  revision 2014-12-10 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7407: A YANG Data Model for SNMP Configuration";
+  }
+
+  /* Collection of SNMP-specific data types */
+
+  typedef admin-string {
+    type string {
+      length "0..255";
+    }
+    description
+      "Represents SnmpAdminString as defined in RFC 3411.
+
+      Note that the size of an SnmpAdminString is measured in
+      octets, not characters.";
+
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks.
+         SNMP-FRAMEWORK-MIB.SnmpAdminString";
+  }
+
+  typedef identifier {
+    type admin-string {
+      length "1..32";
+    }
+    description
+      "Identifiers are used to name items in the SNMP configuration
+      datastore.";
+  }
+
+  typedef context-name {
+    type admin-string {
+      length "0..32";
+    }
+    description
+      "The context type represents an SNMP context name.";
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks";
+  }
+
+  typedef security-name {
+    type admin-string {
+      length "1..32";
+    }
+    description
+      "The security-name type represents an SNMP security name.";
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks";
+  }
+
+  typedef security-model {
+    type union {
+      type enumeration {
+        enum v1  { value 1; }
+        enum v2c { value 2; }
+        enum usm { value 3; }
+        enum tsm { value 4; }
+      }
+      type int32 {
+        range "1..2147483647";
+      }
+    }
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks";
+  }
+
+  typedef security-model-or-any {
+    type union {
+      type enumeration {
+        enum any { value 0; }
+      }
+      type security-model;
+    }
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks";
+  }
+
+  typedef security-level {
+    type enumeration {
+      enum no-auth-no-priv { value 1; }
+      enum auth-no-priv    { value 2; }
+      enum auth-priv       { value 3; }
+    }
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks";
+  }
+
+  typedef engine-id {
+    type yang:hex-string {
+      pattern '([0-9a-fA-F]){2}(:([0-9a-fA-F]){2}){4,31}';
+    }
+    description
+      "The engine ID specified as a list of colon-specified
+      hexadecimal octets, e.g., '80:00:02:b8:04:61:62:63'.";
+    reference
+      "RFC 3411: An Architecture for Describing Simple Network
+         Management Protocol (SNMP) Management Frameworks";
+  }
+
+  typedef wildcard-object-identifier {
+    type string;
+    description
+      "The wildcard-object-identifier type represents an SNMP object
+      identifier where subidentifiers can be given either as a label,
+      in numeric form, or a wildcard, represented by an asterisk
+      ('*').";
+  }
+
+  typedef tag-value {
+    type string {
+      length "0..255";
+    }
+    description
+      "Represents SnmpTagValue as defined in RFC 3413.
+
+      Note that the size of an SnmpTagValue is measured in
+      octets, not characters.";
+    reference
+      "RFC 3413: Simple Network Management Protocol (SNMP)
+         Applications.
+         SNMP-TARGET-MIB.SnmpTagValue";
+  }
+
+  typedef view-name {
+    type snmp:identifier;
+    description
+      "The view-name type represents an SNMP VACM view name.";
+  }
+
+  typedef group-name {
+    type snmp:identifier;
+    description
+      "The group-name type represents an SNMP VACM group name.";
+  }
+
+  container snmp {
+    description
+      "Top-level container for SNMP-related configuration and
+      status objects.";
+  }
+
+}

--- a/tools/openapi_tests/ietf-snmp-community.yang
+++ b/tools/openapi_tests/ietf-snmp-community.yang
@@ -1,0 +1,234 @@
+submodule ietf-snmp-community {
+
+  belongs-to ietf-snmp {
+    prefix snmp;
+  }
+
+  include ietf-snmp-common;
+  include ietf-snmp-target;
+  include ietf-snmp-proxy;
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+    "This submodule contains a collection of YANG definitions
+     for configuring community-based SNMP.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7407; see
+     the RFC itself for full legal notices.";
+
+  reference
+    "RFC 3584: Coexistence between Version 1, Version 2, and
+       Version 3 of the Internet-standard Network
+       Management Framework";
+
+  revision 2014-12-10 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7407: A YANG Data Model for SNMP Configuration";
+  }
+
+  augment /snmp:snmp {
+
+    list community {
+      key index;
+
+      description
+        "List of communities.";
+      reference
+        "RFC 3584: Coexistence between Version 1, Version 2,
+           and Version 3 of the Internet-standard
+           Network Management Framework.
+           SNMP-COMMUNITY-MIB.snmpCommunityTable";
+
+      leaf index {
+        type snmp:identifier;
+        description
+          "Index into the community list.";
+        reference
+          "RFC 3584: Coexistence between Version 1, Version 2,
+             and Version 3 of the Internet-standard
+             Network Management Framework.
+             SNMP-COMMUNITY-MIB.snmpCommunityIndex";
+      }
+      choice name {
+        description
+          "The community name, specified as either a string or
+           a binary value.  The binary name is used when the
+           community name contains characters that are not legal
+           in a string.
+
+           If not set, the value of 'security-name' is operationally
+           used as the snmpCommunityName.";
+        reference
+          "RFC 3584: Coexistence between Version 1, Version 2,
+             and Version 3 of the Internet-standard
+             Network Management Framework.
+             SNMP-COMMUNITY-MIB.snmpCommunityName";
+        leaf text-name {
+          type string;
+          description
+            "A community name that can be represented as a
+             YANG string.";
+        }
+        leaf binary-name {
+          type binary;
+          description
+            "A community name represented as a binary value.";
+        }
+      }
+      leaf security-name {
+        type snmp:security-name;
+        mandatory true;
+        description
+          "The snmpCommunitySecurityName of this entry.";
+        reference
+          "RFC 3584: Coexistence between Version 1, Version 2,
+             and Version 3 of the Internet-standard
+             Network Management Framework.
+             SNMP-COMMUNITY-MIB.snmpCommunitySecurityName";
+      }
+      leaf engine-id {
+        if-feature snmp:proxy;
+        type snmp:engine-id;
+        description
+          "If not set, the value of the local SNMP engine is
+           operationally used by the device.";
+        reference
+          "RFC 3584: Coexistence between Version 1, Version 2,
+             and Version 3 of the Internet-standard
+             Network Management Framework.
+             SNMP-COMMUNITY-MIB.snmpCommunityContextEngineID";
+      }
+      leaf context {
+        type snmp:context-name;
+        default "";
+        description
+          "The context in which management information is accessed
+           when using the community string specified by this entry.";
+        reference
+          "RFC 3584: Coexistence between Version 1, Version 2,
+             and Version 3 of the Internet-standard
+             Network Management Framework.
+             SNMP-COMMUNITY-MIB.snmpCommunityContextName";
+      }
+      leaf target-tag {
+        type snmp:tag-value;
+        description
+          "Used to limit access for this community to the specified
+           targets.
+
+           Implementations MAY restrict the values of this leaf
+           to be one of the available values of /snmp/target/tag in
+           a valid configuration.";
+        reference
+          "RFC 3584: Coexistence between Version 1, Version 2,
+             and Version 3 of the Internet-standard
+             Network Management Framework.
+             SNMP-COMMUNITY-MIB.snmpCommunityTransportTag";
+      }
+    }
+  }
+
+  grouping v1-target-params {
+    container v1 {
+      description
+        "SNMPv1 parameters type.
+         Represents snmpTargetParamsMPModel '0',
+         snmpTargetParamsSecurityModel '1', and
+         snmpTargetParamsSecurityLevel 'noAuthNoPriv'.";
+      leaf security-name {
+        type snmp:security-name;
+        mandatory true;
+        description
+          "Implementations MAY restrict the values of this leaf
+           to be one of the available values of
+           /snmp/community/security-name in a valid configuration.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetParamsSecurityName";
+      }
+    }
+  }
+
+  grouping v2c-target-params {
+    container v2c {
+      description
+        "SNMPv2 community parameters type.
+         Represents snmpTargetParamsMPModel '1',
+         snmpTargetParamsSecurityModel '2', and
+         snmpTargetParamsSecurityLevel 'noAuthNoPriv'.";
+      leaf security-name {
+        type snmp:security-name;
+        mandatory true;
+        description
+          "Implementations MAY restrict the values of this leaf
+           to be one of the available values of
+           /snmp/community/security-name in a valid configuration.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetParamsSecurityName";
+      }
+    }
+  }
+
+  augment /snmp:snmp/snmp:target-params/snmp:params {
+    case v1 {
+      uses v1-target-params;
+    }
+    case v2c {
+      uses v2c-target-params;
+    }
+  }
+
+  augment /snmp:snmp/snmp:target {
+    leaf mms {
+      type union {
+        type enumeration {
+          enum "unknown" { value 0; }
+        }
+        type int32 {
+          range "484..max";
+        }
+      }
+      default "484";
+      description
+        "The maximum message size.";
+      reference
+        "RFC 3584: Coexistence between Version 1, Version 2,
+           and Version 3 of the Internet-standard
+           Network Management Framework.
+           SNMP-COMMUNITY-MIB.snmpTargetAddrMMS";
+    }
+  }
+
+}

--- a/tools/openapi_tests/ietf-snmp-proxy.yang
+++ b/tools/openapi_tests/ietf-snmp-proxy.yang
@@ -1,0 +1,155 @@
+submodule ietf-snmp-proxy {
+
+  belongs-to ietf-snmp {
+    prefix snmp;
+  }
+
+  include ietf-snmp-common;
+  include ietf-snmp-target;
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+    "This submodule contains a collection of YANG definitions
+     for configuring SNMP proxies.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7407; see
+     the RFC itself for full legal notices.";
+  reference
+    "RFC 3413: Simple Network Management Protocol (SNMP)
+       Applications";
+
+  revision 2014-12-10 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7407: A YANG Data Model for SNMP Configuration";
+  }
+
+  feature proxy {
+    description
+      "A server implements this feature if it can act as an
+      SNMP proxy.";
+    reference
+      "RFC 3413: Simple Network Management Protocol (SNMP)
+         Applications";
+  }
+
+  augment /snmp:snmp {
+    if-feature snmp:proxy;
+
+    list proxy {
+      key name;
+
+      description
+        "List of proxy parameters.";
+      reference
+        "RFC 3413: Simple Network Management Protocol (SNMP).
+           Applications.
+           SNMP-PROXY-MIB.snmpProxyTable";
+
+      leaf name {
+        type snmp:identifier;
+        description
+          "Identifies the proxy parameter entry.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxyName";
+      }
+      leaf type {
+        type enumeration {
+          enum read { value 1; }
+          enum write { value 2; }
+          enum trap { value 3; }
+          enum inform { value 4; }
+        }
+        mandatory true;
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxyType";
+      }
+      leaf context-engine-id {
+        type snmp:engine-id;
+        mandatory true;
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxyContextEngineID";
+      }
+      leaf context-name {
+        type snmp:context-name;
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxyContextName";
+      }
+      leaf target-params-in {
+        type snmp:identifier;
+        description
+          "The name of a target parameters list entry.
+
+           Implementations MAY restrict the values of this
+           leaf to be one of the available values of
+           /snmp/target-params/name in a valid configuration.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxyTargetParamsIn";
+      }
+      leaf single-target-out {
+        when "../type = 'read' or ../type = 'write'";
+        type snmp:identifier;
+        description
+          "Implementations MAY restrict the values of this leaf
+           to be one of the available values of /snmp/target/name in
+           a valid configuration.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxySingleTargetOut";
+      }
+
+      leaf multiple-target-out {
+        when "../type = 'trap' or ../type = 'inform'";
+        type snmp:tag-value;
+        description
+          "Implementations MAY restrict the values of this leaf
+           to be one of the available values of /snmp/target/tag in
+           a valid configuration.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-PROXY-MIB.snmpProxyMultipleTargetOut";
+      }
+    }
+  }
+}

--- a/tools/openapi_tests/ietf-snmp-target.yang
+++ b/tools/openapi_tests/ietf-snmp-target.yang
@@ -1,0 +1,207 @@
+submodule ietf-snmp-target {
+
+  belongs-to ietf-snmp {
+    prefix snmp;
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  include ietf-snmp-common;
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+    "This submodule contains a collection of YANG definitions
+     for configuring SNMP targets.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+     This version of this YANG module is part of RFC 7407; see
+     the RFC itself for full legal notices.";
+
+  reference
+    "RFC 3413: Simple Network Management Protocol (SNMP)
+       Applications";
+
+  revision 2014-12-10 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7407: A YANG Data Model for SNMP Configuration";
+  }
+
+  augment /snmp:snmp {
+
+    list target {
+      key name;
+      description
+        "List of targets.";
+      reference
+        "RFC 3413: Simple Network Management Protocol (SNMP)
+           Applications.
+           SNMP-TARGET-MIB.snmpTargetAddrTable";
+
+      leaf name {
+        type snmp:identifier;
+        description
+          "Identifies the target.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP)
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetAddrName";
+      }
+      choice transport {
+        mandatory true;
+        description
+          "Transport address of the target.
+
+           The snmpTargetAddrTDomain and snmpTargetAddrTAddress
+           objects are mapped to transport-specific YANG nodes.  Each
+           transport is configured as a separate case in this
+           choice.  Submodules providing configuration for additional
+           transports are expected to augment this choice.";
+
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP)
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetAddrTDomain
+             SNMP-TARGET-MIB.snmpTargetAddrTAddress";
+        case udp {
+          reference
+           "RFC 3417: Transport Mappings for the Simple Network
+              Management Protocol (SNMP).
+              SNMPv2-TM.snmpUDPDomain
+            RFC 3419: Textual Conventions for Transport Addresses.
+              TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4
+              TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4z
+              TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6
+              TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6z";
+          container udp {
+            leaf ip {
+              type inet:ip-address;
+              mandatory true;
+              reference
+                "RFC 3413: Simple Network Management Protocol (SNMP).
+                   SNMP-TARGET-MIB.snmpTargetAddrTAddress";
+            }
+            leaf port {
+              type inet:port-number;
+              default 162;
+              description
+                "UDP port number.";
+              reference
+                "RFC 3413: Simple Network Management Protocol (SNMP).
+                   SNMP-TARGET-MIB.snmpTargetAddrTAddress";
+            }
+            leaf prefix-length {
+              type uint8;
+              description
+                "The value of this leaf must match the value of
+                 ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+                 this leaf must be less than or equal to 32.  If it
+                 contains an IPv6 address, it must be less than or
+                 equal to 128.
+
+                 Note that the prefix-length is currently only used
+                 by the Community-based Security Model to filter
+                 incoming messages.  Furthermore, the prefix-length
+                 filtering does not cover all possible filters
+                 supported by the corresponding MIB object.";
+
+              reference
+                "RFC 3584: Coexistence between Version 1, Version 2,
+                   and Version 3 of the Internet-standard
+                   Network Management Framework.
+                   SNMP-COMMUNITY-MIB.snmpTargetAddrTMask";
+            }
+          }
+        }
+      }
+      leaf-list tag {
+        type snmp:tag-value;
+        description
+          "List of tag values used to select target addresses.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetAddrTagList";
+      }
+      leaf timeout {
+        type uint32;
+        units "0.01 seconds";
+        default 1500;
+        description
+          "Needed only if this target can receive
+           InformRequest-PDUs.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetAddrTimeout";
+      }
+      leaf retries {
+        type uint8;
+        default 3;
+        description
+          "Needed only if this target can receive
+           InformRequest-PDUs.";
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetAddrRetryCount";
+      }
+      leaf target-params {
+        type snmp:identifier;
+        mandatory true;
+        reference
+          "RFC 3413: Simple Network Management Protocol (SNMP).
+             Applications.
+             SNMP-TARGET-MIB.snmpTargetAddrParams";
+      }
+    }
+
+    list target-params {
+      key name;
+      description
+        "List of target parameters.";
+      reference
+        "RFC 3413: Simple Network Management Protocol (SNMP).
+           Applications.
+           SNMP-TARGET-MIB.snmpTargetParamsTable";
+
+      leaf name {
+        type snmp:identifier;
+      }
+      choice params {
+        description
+          "This choice is augmented with case nodes containing
+           configuration parameters specific to the security model.";
+      }
+    }
+  }
+}

--- a/tools/openapi_tests/ietf-snmp.no-oneof.yang.expect
+++ b/tools/openapi_tests/ietf-snmp.no-oneof.yang.expect
@@ -1,0 +1,8990 @@
+openapi: 3.0.1
+info:
+  description: Network Management Open APIs for SONiC
+  version: 1.0.0
+  title: Sonic Network Management RESTCONF APIs
+servers:
+- url: https://
+security:
+- basic: []
+- bearer: []
+tags:
+- name: ietf-snmp
+  description: Operations for ietf-snmp
+paths:
+  /restconf/data/ietf-snmp:snmp:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp
+      x-operationIdCamelCase: PutIetfSnmpSnmp
+      description: 'OperationId: put_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp
+      x-operationIdCamelCase: PatchIetfSnmpSnmp
+      description: 'OperationId: patch_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp
+      x-operationIdCamelCase: GetIetfSnmpSnmp
+      description: 'OperationId: get_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp
+      x-operationIdCamelCase: HeadIetfSnmpSnmp
+      description: 'OperationId: head_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp
+      x-operationIdCamelCase: DeleteIetfSnmpSnmp
+      description: 'OperationId: delete_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PostListIetfSnmpSnmpTarget
+      description: 'OperationId: post_list_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_list_ietf_snmp_snmp_target'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target={name}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PutIetfSnmpSnmpTarget
+      description: 'OperationId: put_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTarget
+      description: 'OperationId: patch_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target
+      x-operationIdCamelCase: GetIetfSnmpSnmpTarget
+      description: 'OperationId: get_ietf_snmp_snmp_target
+
+        List of targets.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTarget
+      description: 'OperationId: head_ietf_snmp_snmp_target
+
+        List of targets.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTarget
+      description: 'OperationId: delete_ietf_snmp_snmp_target
+
+        List of targets.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: post_ietf_snmp_snmp_target_transport_udp
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_transport_udp'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PutListIetfSnmpSnmpTarget
+      description: 'OperationId: put_list_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_target'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpTarget
+      description: 'OperationId: patch_list_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_target'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: GetListIetfSnmpSnmpTarget
+      description: 'OperationId: get_list_ietf_snmp_snmp_target
+
+        List of targets.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpTarget
+      description: 'OperationId: head_list_ietf_snmp_snmp_target
+
+        List of targets.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpTarget
+      description: 'OperationId: delete_list_ietf_snmp_snmp_target
+
+        List of targets.'
+  /restconf/data/ietf-snmp:snmp/target={name}/udp:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp
+
+        '
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: post_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_transport_udp_ip'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target={name}/udp/ip:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp_ip'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp_ip'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp_ip'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+  /restconf/data/ietf-snmp:snmp/target={name}/udp/port:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp_port'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp_port'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp_port'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+  /restconf/data/ietf-snmp:snmp/target={name}/udp/prefix-length:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp_prefix_length'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp_prefix_length'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp_prefix_length'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+  /restconf/data/ietf-snmp:snmp/target={name}/tag:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTag
+      description: 'OperationId: put_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_tag'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTag
+      description: 'OperationId: patch_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_tag'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_tag'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTag
+      description: 'OperationId: get_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTag
+      description: 'OperationId: head_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTag
+      description: 'OperationId: delete_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+  /restconf/data/ietf-snmp:snmp/target={name}/tag={tag}:
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      - name: tag
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: List of tag values used to select target addresses.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_tag'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_llist_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: GetLlistIetfSnmpSnmpTargetTag
+      description: 'OperationId: get_llist_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      - name: tag
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: List of tag values used to select target addresses.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_llist_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: HeadLlistIetfSnmpSnmpTargetTag
+      description: 'OperationId: head_llist_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      - name: tag
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: List of tag values used to select target addresses.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: del_llist_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: DelLlistIetfSnmpSnmpTargetTag
+      description: 'OperationId: del_llist_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+  /restconf/data/ietf-snmp:snmp/target={name}/timeout:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: put_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_timeout'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: patch_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_timeout'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_timeout'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: get_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: head_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: delete_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+  /restconf/data/ietf-snmp:snmp/target={name}/retries:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetRetries
+      description: 'OperationId: put_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_retries'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetRetries
+      description: 'OperationId: patch_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_retries'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_retries'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetRetries
+      description: 'OperationId: get_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetRetries
+      description: 'OperationId: head_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetRetries
+      description: 'OperationId: delete_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+  /restconf/data/ietf-snmp:snmp/target={name}/target-params:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: put_ietf_snmp_snmp_target_target_params
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_target_params'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: patch_ietf_snmp_snmp_target_target_params
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_target_params'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_target_params'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: get_ietf_snmp_snmp_target_target_params
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: head_ietf_snmp_snmp_target_target_params
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: delete_ietf_snmp_snmp_target_target_params
+
+        '
+  /restconf/data/ietf-snmp:snmp/target={name}/mms:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetMms
+      description: 'OperationId: put_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_mms'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetMms
+      description: 'OperationId: patch_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_mms'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_mms'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetMms
+      description: 'OperationId: get_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetMms
+      description: 'OperationId: head_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetMms
+      description: 'OperationId: delete_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+  /restconf/data/ietf-snmp:snmp/target-params={name}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParams
+      description: 'OperationId: put_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParams
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParams
+      description: 'OperationId: get_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParams
+      description: 'OperationId: head_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParams
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: post_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_params_params_v1'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target-params:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PutListIetfSnmpSnmpTargetParams
+      description: 'OperationId: put_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_target_params'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpTargetParams
+      description: 'OperationId: patch_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_target_params'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: GetListIetfSnmpSnmpTargetParams
+      description: 'OperationId: get_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpTargetParams
+      description: 'OperationId: head_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpTargetParams
+      description: 'OperationId: delete_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v1:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v1'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v1'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v1'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: post_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_params_params_v1_security_name'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v1/security-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v1_security_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v1_security_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v1_security_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v2c:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v2c'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v2c'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v2c'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: post_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_params_params_v2c_security_name'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v2c/security-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v2c_security_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v2c_security_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v2c_security_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxy
+      description: 'OperationId: put_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxy
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxy
+      description: 'OperationId: get_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxy
+      description: 'OperationId: head_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxy
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: PostIetfSnmpSnmpProxyType
+      description: 'OperationId: post_ietf_snmp_snmp_proxy_type
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_proxy_type'
+        required: true
+  /restconf/data/ietf-snmp:snmp/proxy:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PutListIetfSnmpSnmpProxy
+      description: 'OperationId: put_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_proxy'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpProxy
+      description: 'OperationId: patch_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_proxy'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: GetListIetfSnmpSnmpProxy
+      description: 'OperationId: get_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpProxy
+      description: 'OperationId: head_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpProxy
+      description: 'OperationId: delete_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}/type:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyType
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_type
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_type'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyType
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_type
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_type'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_type'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyType
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_type
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyType
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_type
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyType
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_type
+
+        '
+  /restconf/data/ietf-snmp:snmp/proxy={name}/context-engine-id:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_context_engine_id'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_context_engine_id'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_context_engine_id'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+  /restconf/data/ietf-snmp:snmp/proxy={name}/context-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyContextName
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_context_name
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_context_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyContextName
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_context_name
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_context_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_context_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyContextName
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_context_name
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyContextName
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_context_name
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyContextName
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_context_name
+
+        '
+  /restconf/data/ietf-snmp:snmp/proxy={name}/target-params-in:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_target_params_in'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_target_params_in'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_target_params_in'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}/single-target-out:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_single_target_out'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_single_target_out'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_single_target_out'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}/multiple-target-out:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_multiple_target_out'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_multiple_target_out'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_multiple_target_out'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/community={index}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunity
+      description: 'OperationId: put_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunity
+      description: 'OperationId: patch_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunity
+      description: 'OperationId: get_ietf_snmp_snmp_community
+
+        List of communities.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunity
+      description: 'OperationId: head_ietf_snmp_snmp_community
+
+        List of communities.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunity
+      description: 'OperationId: delete_ietf_snmp_snmp_community
+
+        List of communities.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: PostIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: post_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_community_name_text_name'
+        required: true
+  /restconf/data/ietf-snmp:snmp/community:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PutListIetfSnmpSnmpCommunity
+      description: 'OperationId: put_list_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_community'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpCommunity
+      description: 'OperationId: patch_list_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_community'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: GetListIetfSnmpSnmpCommunity
+      description: 'OperationId: get_list_ietf_snmp_snmp_community
+
+        List of communities.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpCommunity
+      description: 'OperationId: head_list_ietf_snmp_snmp_community
+
+        List of communities.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpCommunity
+      description: 'OperationId: delete_list_ietf_snmp_snmp_community
+
+        List of communities.'
+  /restconf/data/ietf-snmp:snmp/community={index}/text-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: put_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_name_text_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: patch_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_name_text_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_name_text_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: get_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: head_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: delete_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+  /restconf/data/ietf-snmp:snmp/community={index}/binary-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: put_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_name_binary_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: patch_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_name_binary_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_name_binary_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: get_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: head_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: delete_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+  /restconf/data/ietf-snmp:snmp/community={index}/security-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: put_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_security_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: patch_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_security_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_security_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: get_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: head_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: delete_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+  /restconf/data/ietf-snmp:snmp/community={index}/engine-id:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: put_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_engine_id'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: patch_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_engine_id'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_engine_id'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: get_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: head_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: delete_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+  /restconf/data/ietf-snmp:snmp/community={index}/context:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityContext
+      description: 'OperationId: put_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_context'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityContext
+      description: 'OperationId: patch_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_context'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_context'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityContext
+      description: 'OperationId: get_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityContext
+      description: 'OperationId: head_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityContext
+      description: 'OperationId: delete_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+  /restconf/data/ietf-snmp:snmp/community={index}/target-tag:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: put_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_target_tag'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: patch_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_target_tag'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_target_tag'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: get_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: head_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: delete_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+components:
+  securitySchemes:
+    basic:
+      scheme: basic
+      type: http
+    bearer:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http
+  schemas:
+    ietf_snmp_snmp:
+      type: object
+      properties:
+        ietf-snmp:snmp:
+          type: object
+          properties:
+            target:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - target-params
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  udp:
+                    type: object
+                    properties:
+                      ip:
+                        maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-yang-type: string
+                      port:
+                        default: 162
+                        format: int32
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                        x-range: 0..65535
+                        x-yang-type: uint16
+                      prefix-length:
+                        format: int32
+                        maximum: 255
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint8
+                    required:
+                    - ip
+                  tag:
+                    type: array
+                    items:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  timeout:
+                    default: 1500
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  retries:
+                    default: 3
+                    format: int32
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint8
+                  target-params:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  mms:
+                    default: 484
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+            target-params:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  v1:
+                    type: object
+                    properties:
+                      security-name:
+                        maxLength: 255
+                        minLength: 0
+                        type: string
+                        x-length: 0..255
+                        x-yang-type: string
+                    required:
+                    - security-name
+                  v2c:
+                    type: object
+                    properties:
+                      security-name:
+                        maxLength: 255
+                        minLength: 0
+                        type: string
+                        x-length: 0..255
+                        x-yang-type: string
+                    required:
+                    - security-name
+            proxy:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                - context-engine-id
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  type:
+                    enum:
+                    - read
+                    - write
+                    - trap
+                    - inform
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  context-engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-params-in:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  single-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  multiple-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+            community:
+              type: array
+              items:
+                type: object
+                required:
+                - index
+                - security-name
+                properties:
+                  index:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  text-name:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  binary-name:
+                    format: binary
+                    type: string
+                    x-yang-type: binary
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context:
+                    default: ''
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-tag:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+    post_ietf_snmp_snmp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp'
+    put_ietf_snmp_snmp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp'
+    patch_ietf_snmp_snmp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp'
+    get_ietf_snmp_snmp:
+      type: object
+      properties:
+        ietf-snmp:snmp:
+          type: object
+          properties:
+            target:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - target-params
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  udp:
+                    type: object
+                    properties:
+                      ip:
+                        maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-yang-type: string
+                      port:
+                        default: 162
+                        format: int32
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                        x-range: 0..65535
+                        x-yang-type: uint16
+                      prefix-length:
+                        format: int32
+                        maximum: 255
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint8
+                    required:
+                    - ip
+                  tag:
+                    type: array
+                    items:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  timeout:
+                    default: 1500
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  retries:
+                    default: 3
+                    format: int32
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint8
+                  target-params:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  mms:
+                    default: 484
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+            target-params:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  v1:
+                    type: object
+                    properties:
+                      security-name:
+                        maxLength: 255
+                        minLength: 0
+                        type: string
+                        x-length: 0..255
+                        x-yang-type: string
+                    required:
+                    - security-name
+                  v2c:
+                    type: object
+                    properties:
+                      security-name:
+                        maxLength: 255
+                        minLength: 0
+                        type: string
+                        x-length: 0..255
+                        x-yang-type: string
+                    required:
+                    - security-name
+            proxy:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                - context-engine-id
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  type:
+                    enum:
+                    - read
+                    - write
+                    - trap
+                    - inform
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  context-engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-params-in:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  single-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  multiple-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+            community:
+              type: array
+              items:
+                type: object
+                required:
+                - index
+                - security-name
+                properties:
+                  index:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  text-name:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  binary-name:
+                    format: binary
+                    type: string
+                    x-yang-type: binary
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context:
+                    default: ''
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-tag:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+    ietf_snmp_snmp_target:
+      type: object
+      properties:
+        ietf-snmp:target:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - target-params
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              udp:
+                type: object
+                properties:
+                  ip:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  port:
+                    default: 162
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                    x-range: 0..65535
+                    x-yang-type: uint16
+                  prefix-length:
+                    format: int32
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint8
+                required:
+                - ip
+              tag:
+                type: array
+                items:
+                  maxLength: 255
+                  minLength: 0
+                  type: string
+                  x-length: 0..255
+                  x-yang-type: string
+              timeout:
+                default: 1500
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+                x-yang-type: uint32
+              retries:
+                default: 3
+                format: int32
+                maximum: 255
+                minimum: 0
+                type: integer
+                x-yang-type: uint8
+              target-params:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              mms:
+                default: 484
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+    put_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    patch_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    get_ietf_snmp_snmp_target:
+      type: object
+      properties:
+        ietf-snmp:target:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - target-params
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              udp:
+                type: object
+                properties:
+                  ip:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  port:
+                    default: 162
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                    x-range: 0..65535
+                    x-yang-type: uint16
+                  prefix-length:
+                    format: int32
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint8
+                required:
+                - ip
+              tag:
+                type: array
+                items:
+                  maxLength: 255
+                  minLength: 0
+                  type: string
+                  x-length: 0..255
+                  x-yang-type: string
+              timeout:
+                default: 1500
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+                x-yang-type: uint32
+              retries:
+                default: 3
+                format: int32
+                maximum: 255
+                minimum: 0
+                type: integer
+                x-yang-type: uint8
+              target-params:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              mms:
+                default: 484
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+    post_list_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    put_list_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    patch_list_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    ietf_snmp_snmp_target_transport_udp:
+      type: object
+      properties:
+        ietf-snmp:udp:
+          type: object
+          properties:
+            ip:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+            port:
+              default: 162
+              format: int32
+              maximum: 65535
+              minimum: 0
+              type: integer
+              x-range: 0..65535
+              x-yang-type: uint16
+            prefix-length:
+              format: int32
+              maximum: 255
+              minimum: 0
+              type: integer
+              x-yang-type: uint8
+          required:
+          - ip
+    post_ietf_snmp_snmp_target_transport_udp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_tag'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_timeout'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_retries'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_target_params'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_mms'
+    put_ietf_snmp_snmp_target_transport_udp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp'
+    patch_ietf_snmp_snmp_target_transport_udp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp'
+    get_ietf_snmp_snmp_target_transport_udp:
+      type: object
+      properties:
+        ietf-snmp:udp:
+          type: object
+          properties:
+            ip:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+            port:
+              default: 162
+              format: int32
+              maximum: 65535
+              minimum: 0
+              type: integer
+              x-range: 0..65535
+              x-yang-type: uint16
+            prefix-length:
+              format: int32
+              maximum: 255
+              minimum: 0
+              type: integer
+              x-yang-type: uint8
+          required:
+          - ip
+    ietf_snmp_snmp_target_transport_udp_ip:
+      type: object
+      properties:
+        ietf-snmp:ip:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    post_ietf_snmp_snmp_target_transport_udp_ip:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_ip'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_port'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_prefix_length'
+    put_ietf_snmp_snmp_target_transport_udp_ip:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_ip'
+    patch_ietf_snmp_snmp_target_transport_udp_ip:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_ip'
+    get_ietf_snmp_snmp_target_transport_udp_ip:
+      type: object
+      properties:
+        ietf-snmp:ip:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    ietf_snmp_snmp_target_transport_udp_port:
+      type: object
+      properties:
+        ietf-snmp:port:
+          default: 162
+          format: int32
+          maximum: 65535
+          minimum: 0
+          type: integer
+          x-range: 0..65535
+          x-yang-type: uint16
+    put_ietf_snmp_snmp_target_transport_udp_port:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_port'
+    patch_ietf_snmp_snmp_target_transport_udp_port:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_port'
+    get_ietf_snmp_snmp_target_transport_udp_port:
+      type: object
+      properties:
+        ietf-snmp:port:
+          default: 162
+          format: int32
+          maximum: 65535
+          minimum: 0
+          type: integer
+          x-range: 0..65535
+          x-yang-type: uint16
+    ietf_snmp_snmp_target_transport_udp_prefix_length:
+      type: object
+      properties:
+        ietf-snmp:prefix-length:
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    put_ietf_snmp_snmp_target_transport_udp_prefix_length:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_prefix_length'
+    patch_ietf_snmp_snmp_target_transport_udp_prefix_length:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_prefix_length'
+    get_ietf_snmp_snmp_target_transport_udp_prefix_length:
+      type: object
+      properties:
+        ietf-snmp:prefix-length:
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    ietf_snmp_snmp_target_tag:
+      type: object
+      properties:
+        ietf-snmp:tag:
+          type: array
+          items:
+            maxLength: 255
+            minLength: 0
+            type: string
+            x-length: 0..255
+            x-yang-type: string
+    put_ietf_snmp_snmp_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_tag'
+    patch_ietf_snmp_snmp_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_tag'
+    get_ietf_snmp_snmp_target_tag:
+      type: object
+      properties:
+        ietf-snmp:tag:
+          type: array
+          items:
+            maxLength: 255
+            minLength: 0
+            type: string
+            x-length: 0..255
+            x-yang-type: string
+    ietf_snmp_snmp_target_timeout:
+      type: object
+      properties:
+        ietf-snmp:timeout:
+          default: 1500
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    put_ietf_snmp_snmp_target_timeout:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_timeout'
+    patch_ietf_snmp_snmp_target_timeout:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_timeout'
+    get_ietf_snmp_snmp_target_timeout:
+      type: object
+      properties:
+        ietf-snmp:timeout:
+          default: 1500
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    ietf_snmp_snmp_target_retries:
+      type: object
+      properties:
+        ietf-snmp:retries:
+          default: 3
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    put_ietf_snmp_snmp_target_retries:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_retries'
+    patch_ietf_snmp_snmp_target_retries:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_retries'
+    get_ietf_snmp_snmp_target_retries:
+      type: object
+      properties:
+        ietf-snmp:retries:
+          default: 3
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    ietf_snmp_snmp_target_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_target_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_target_params'
+    patch_ietf_snmp_snmp_target_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_target_params'
+    get_ietf_snmp_snmp_target_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_target_mms:
+      type: object
+      properties:
+        ietf-snmp:mms:
+          default: 484
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    put_ietf_snmp_snmp_target_mms:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_mms'
+    patch_ietf_snmp_snmp_target_mms:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_mms'
+    get_ietf_snmp_snmp_target_mms:
+      type: object
+      properties:
+        ietf-snmp:mms:
+          default: 484
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    ietf_snmp_snmp_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              v1:
+                type: object
+                properties:
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                required:
+                - security-name
+              v2c:
+                type: object
+                properties:
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                required:
+                - security-name
+    put_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    patch_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    get_ietf_snmp_snmp_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              v1:
+                type: object
+                properties:
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                required:
+                - security-name
+              v2c:
+                type: object
+                properties:
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                required:
+                - security-name
+    put_list_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    patch_list_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    ietf_snmp_snmp_target_params_params_v1:
+      type: object
+      properties:
+        ietf-snmp:v1:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    post_ietf_snmp_snmp_target_params_params_v1:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c'
+    put_ietf_snmp_snmp_target_params_params_v1:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1'
+    patch_ietf_snmp_snmp_target_params_params_v1:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1'
+    get_ietf_snmp_snmp_target_params_params_v1:
+      type: object
+      properties:
+        ietf-snmp:v1:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    ietf_snmp_snmp_target_params_params_v1_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    post_ietf_snmp_snmp_target_params_params_v1_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1_security_name'
+    put_ietf_snmp_snmp_target_params_params_v1_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1_security_name'
+    patch_ietf_snmp_snmp_target_params_params_v1_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1_security_name'
+    get_ietf_snmp_snmp_target_params_params_v1_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_target_params_params_v2c:
+      type: object
+      properties:
+        ietf-snmp:v2c:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    put_ietf_snmp_snmp_target_params_params_v2c:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c'
+    patch_ietf_snmp_snmp_target_params_params_v2c:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c'
+    get_ietf_snmp_snmp_target_params_params_v2c:
+      type: object
+      properties:
+        ietf-snmp:v2c:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    ietf_snmp_snmp_target_params_params_v2c_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    post_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c_security_name'
+    put_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c_security_name'
+    patch_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c_security_name'
+    get_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy:
+      type: object
+      properties:
+        ietf-snmp:proxy:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            - context-engine-id
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              type:
+                enum:
+                - read
+                - write
+                - trap
+                - inform
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              context-engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-params-in:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              single-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              multiple-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+    put_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    patch_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    get_ietf_snmp_snmp_proxy:
+      type: object
+      properties:
+        ietf-snmp:proxy:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            - context-engine-id
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              type:
+                enum:
+                - read
+                - write
+                - trap
+                - inform
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              context-engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-params-in:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              single-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              multiple-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+    put_list_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    patch_list_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    ietf_snmp_snmp_proxy_type:
+      type: object
+      properties:
+        ietf-snmp:type:
+          enum:
+          - read
+          - write
+          - trap
+          - inform
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    post_ietf_snmp_snmp_proxy_type:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_type'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_engine_id'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_target_params_in'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_single_target_out'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_multiple_target_out'
+    put_ietf_snmp_snmp_proxy_type:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_type'
+    patch_ietf_snmp_snmp_proxy_type:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_type'
+    get_ietf_snmp_snmp_proxy_type:
+      type: object
+      properties:
+        ietf-snmp:type:
+          enum:
+          - read
+          - write
+          - trap
+          - inform
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_context_engine_id:
+      type: object
+      properties:
+        ietf-snmp:context-engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_context_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_engine_id'
+    patch_ietf_snmp_snmp_proxy_context_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_engine_id'
+    get_ietf_snmp_snmp_proxy_context_engine_id:
+      type: object
+      properties:
+        ietf-snmp:context-engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_context_name:
+      type: object
+      properties:
+        ietf-snmp:context-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_context_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_name'
+    patch_ietf_snmp_snmp_proxy_context_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_name'
+    get_ietf_snmp_snmp_proxy_context_name:
+      type: object
+      properties:
+        ietf-snmp:context-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_target_params_in:
+      type: object
+      properties:
+        ietf-snmp:target-params-in:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_target_params_in:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_target_params_in'
+    patch_ietf_snmp_snmp_proxy_target_params_in:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_target_params_in'
+    get_ietf_snmp_snmp_proxy_target_params_in:
+      type: object
+      properties:
+        ietf-snmp:target-params-in:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_single_target_out:
+      type: object
+      properties:
+        ietf-snmp:single-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_single_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_single_target_out'
+    patch_ietf_snmp_snmp_proxy_single_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_single_target_out'
+    get_ietf_snmp_snmp_proxy_single_target_out:
+      type: object
+      properties:
+        ietf-snmp:single-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_multiple_target_out:
+      type: object
+      properties:
+        ietf-snmp:multiple-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_multiple_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_multiple_target_out'
+    patch_ietf_snmp_snmp_proxy_multiple_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_multiple_target_out'
+    get_ietf_snmp_snmp_proxy_multiple_target_out:
+      type: object
+      properties:
+        ietf-snmp:multiple-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_community:
+      type: object
+      properties:
+        ietf-snmp:community:
+          type: array
+          items:
+            type: object
+            required:
+            - index
+            - security-name
+            properties:
+              index:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              text-name:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              binary-name:
+                format: binary
+                type: string
+                x-yang-type: binary
+              security-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context:
+                default: ''
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-tag:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+    put_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    patch_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    get_ietf_snmp_snmp_community:
+      type: object
+      properties:
+        ietf-snmp:community:
+          type: array
+          items:
+            type: object
+            required:
+            - index
+            - security-name
+            properties:
+              index:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              text-name:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              binary-name:
+                format: binary
+                type: string
+                x-yang-type: binary
+              security-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context:
+                default: ''
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-tag:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+    put_list_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    patch_list_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    ietf_snmp_snmp_community_name_text_name:
+      type: object
+      properties:
+        ietf-snmp:text-name:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    post_ietf_snmp_snmp_community_name_text_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_text_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_binary_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_security_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_engine_id'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_context'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_target_tag'
+    put_ietf_snmp_snmp_community_name_text_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_text_name'
+    patch_ietf_snmp_snmp_community_name_text_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_text_name'
+    get_ietf_snmp_snmp_community_name_text_name:
+      type: object
+      properties:
+        ietf-snmp:text-name:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    ietf_snmp_snmp_community_name_binary_name:
+      type: object
+      properties:
+        ietf-snmp:binary-name:
+          format: binary
+          type: string
+          x-yang-type: binary
+    put_ietf_snmp_snmp_community_name_binary_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_binary_name'
+    patch_ietf_snmp_snmp_community_name_binary_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_binary_name'
+    get_ietf_snmp_snmp_community_name_binary_name:
+      type: object
+      properties:
+        ietf-snmp:binary-name:
+          format: binary
+          type: string
+          x-yang-type: binary
+    ietf_snmp_snmp_community_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_security_name'
+    patch_ietf_snmp_snmp_community_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_security_name'
+    get_ietf_snmp_snmp_community_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_community_engine_id:
+      type: object
+      properties:
+        ietf-snmp:engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_engine_id'
+    patch_ietf_snmp_snmp_community_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_engine_id'
+    get_ietf_snmp_snmp_community_engine_id:
+      type: object
+      properties:
+        ietf-snmp:engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    ietf_snmp_snmp_community_context:
+      type: object
+      properties:
+        ietf-snmp:context:
+          default: ''
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_context:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_context'
+    patch_ietf_snmp_snmp_community_context:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_context'
+    get_ietf_snmp_snmp_community_context:
+      type: object
+      properties:
+        ietf-snmp:context:
+          default: ''
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_community_target_tag:
+      type: object
+      properties:
+        ietf-snmp:target-tag:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_target_tag'
+    patch_ietf_snmp_snmp_community_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_target_tag'
+    get_ietf_snmp_snmp_community_target_tag:
+      type: object
+      properties:
+        ietf-snmp:target-tag:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string

--- a/tools/openapi_tests/ietf-snmp.yang
+++ b/tools/openapi_tests/ietf-snmp.yang
@@ -1,0 +1,59 @@
+module ietf-snmp {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-snmp";
+  prefix snmp;
+
+  include ietf-snmp-common {
+    revision-date 2014-12-10;
+  }
+  include ietf-snmp-target {
+    revision-date 2014-12-10;
+  }
+  include ietf-snmp-proxy {
+    revision-date 2014-12-10;
+  }
+
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>";
+  description
+    "This module contains a collection of YANG definitions for
+     configuring SNMP engines.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7407; see
+     the RFC itself for full legal notices.";
+
+  revision 2014-12-10 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7407: A YANG Data Model for SNMP Configuration";
+  }
+
+}

--- a/tools/openapi_tests/ietf-snmp.yang.expect
+++ b/tools/openapi_tests/ietf-snmp.yang.expect
@@ -1,0 +1,9168 @@
+openapi: 3.0.1
+info:
+  description: Network Management Open APIs for SONiC
+  version: 1.0.0
+  title: Sonic Network Management RESTCONF APIs
+servers:
+- url: https://
+security:
+- basic: []
+- bearer: []
+tags:
+- name: ietf-snmp
+  description: Operations for ietf-snmp
+paths:
+  /restconf/data/ietf-snmp:snmp:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp
+      x-operationIdCamelCase: PutIetfSnmpSnmp
+      description: 'OperationId: put_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp
+      x-operationIdCamelCase: PatchIetfSnmpSnmp
+      description: 'OperationId: patch_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp
+      x-operationIdCamelCase: GetIetfSnmpSnmp
+      description: 'OperationId: get_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp
+      x-operationIdCamelCase: HeadIetfSnmpSnmp
+      description: 'OperationId: head_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp
+      x-operationIdCamelCase: DeleteIetfSnmpSnmp
+      description: 'OperationId: delete_ietf_snmp_snmp
+
+        Top-level container for SNMP-related configuration and
+
+        status objects.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PostListIetfSnmpSnmpTarget
+      description: 'OperationId: post_list_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_list_ietf_snmp_snmp_target'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target={name}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PutIetfSnmpSnmpTarget
+      description: 'OperationId: put_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTarget
+      description: 'OperationId: patch_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target
+      x-operationIdCamelCase: GetIetfSnmpSnmpTarget
+      description: 'OperationId: get_ietf_snmp_snmp_target
+
+        List of targets.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTarget
+      description: 'OperationId: head_ietf_snmp_snmp_target
+
+        List of targets.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTarget
+      description: 'OperationId: delete_ietf_snmp_snmp_target
+
+        List of targets.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: post_ietf_snmp_snmp_target_transport_udp
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_transport_udp'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PutListIetfSnmpSnmpTarget
+      description: 'OperationId: put_list_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_target'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpTarget
+      description: 'OperationId: patch_list_ietf_snmp_snmp_target
+
+        List of targets.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_target'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: GetListIetfSnmpSnmpTarget
+      description: 'OperationId: get_list_ietf_snmp_snmp_target
+
+        List of targets.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpTarget
+      description: 'OperationId: head_list_ietf_snmp_snmp_target
+
+        List of targets.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_target
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpTarget
+      description: 'OperationId: delete_list_ietf_snmp_snmp_target
+
+        List of targets.'
+  /restconf/data/ietf-snmp:snmp/target={name}/udp:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdp
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp
+
+        '
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: post_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_transport_udp_ip'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target={name}/udp/ip:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp_ip'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp_ip'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp_ip'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp_ip
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdpIp
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp_ip
+
+        '
+  /restconf/data/ietf-snmp:snmp/target={name}/udp/port:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp_port'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp_port'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp_port'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp_port
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdpPort
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp_port
+
+        UDP port number.'
+  /restconf/data/ietf-snmp:snmp/target={name}/udp/prefix-length:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: put_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_transport_udp_prefix_length'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: patch_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_transport_udp_prefix_length'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_transport_udp_prefix_length'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: get_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: head_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_transport_udp_prefix_length
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTransportUdpPrefixLength
+      description: 'OperationId: delete_ietf_snmp_snmp_target_transport_udp_prefix_length
+
+        The value of this leaf must match the value of
+
+        ../snmp:ip.  If ../snmp:ip contains an IPv4 address,
+
+        this leaf must be less than or equal to 32.  If it
+
+        contains an IPv6 address, it must be less than or
+
+        equal to 128.
+
+
+        Note that the prefix-length is currently only used
+
+        by the Community-based Security Model to filter
+
+        incoming messages.  Furthermore, the prefix-length
+
+        filtering does not cover all possible filters
+
+        supported by the corresponding MIB object.'
+  /restconf/data/ietf-snmp:snmp/target={name}/tag:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTag
+      description: 'OperationId: put_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_tag'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTag
+      description: 'OperationId: patch_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_tag'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_tag'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTag
+      description: 'OperationId: get_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTag
+      description: 'OperationId: head_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTag
+      description: 'OperationId: delete_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+  /restconf/data/ietf-snmp:snmp/target={name}/tag={tag}:
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      - name: tag
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: List of tag values used to select target addresses.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_tag'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_llist_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: GetLlistIetfSnmpSnmpTargetTag
+      description: 'OperationId: get_llist_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      - name: tag
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: List of tag values used to select target addresses.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_llist_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: HeadLlistIetfSnmpSnmpTargetTag
+      description: 'OperationId: head_llist_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      - name: tag
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: List of tag values used to select target addresses.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: del_llist_ietf_snmp_snmp_target_tag
+      x-operationIdCamelCase: DelLlistIetfSnmpSnmpTargetTag
+      description: 'OperationId: del_llist_ietf_snmp_snmp_target_tag
+
+        List of tag values used to select target addresses.'
+  /restconf/data/ietf-snmp:snmp/target={name}/timeout:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: put_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_timeout'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: patch_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_timeout'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_timeout'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: get_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: head_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_timeout
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTimeout
+      description: 'OperationId: delete_ietf_snmp_snmp_target_timeout
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+  /restconf/data/ietf-snmp:snmp/target={name}/retries:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetRetries
+      description: 'OperationId: put_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_retries'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetRetries
+      description: 'OperationId: patch_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_retries'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_retries'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetRetries
+      description: 'OperationId: get_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetRetries
+      description: 'OperationId: head_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_retries
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetRetries
+      description: 'OperationId: delete_ietf_snmp_snmp_target_retries
+
+        Needed only if this target can receive
+
+        InformRequest-PDUs.'
+  /restconf/data/ietf-snmp:snmp/target={name}/target-params:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: put_ietf_snmp_snmp_target_target_params
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_target_params'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: patch_ietf_snmp_snmp_target_target_params
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_target_params'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_target_params'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: get_ietf_snmp_snmp_target_target_params
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: head_ietf_snmp_snmp_target_target_params
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_target_params
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetTargetParams
+      description: 'OperationId: delete_ietf_snmp_snmp_target_target_params
+
+        '
+  /restconf/data/ietf-snmp:snmp/target={name}/mms:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetMms
+      description: 'OperationId: put_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_mms'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetMms
+      description: 'OperationId: patch_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_mms'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_mms'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetMms
+      description: 'OperationId: get_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetMms
+      description: 'OperationId: head_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the target.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_mms
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetMms
+      description: 'OperationId: delete_ietf_snmp_snmp_target_mms
+
+        The maximum message size.'
+  /restconf/data/ietf-snmp:snmp/target-params={name}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParams
+      description: 'OperationId: put_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParams
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParams
+      description: 'OperationId: get_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParams
+      description: 'OperationId: head_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParams
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: post_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_params_params_v1'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target-params:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PutListIetfSnmpSnmpTargetParams
+      description: 'OperationId: put_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_target_params'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpTargetParams
+      description: 'OperationId: patch_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_target_params'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: GetListIetfSnmpSnmpTargetParams
+      description: 'OperationId: get_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpTargetParams
+      description: 'OperationId: head_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_target_params
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpTargetParams
+      description: 'OperationId: delete_list_ietf_snmp_snmp_target_params
+
+        List of target parameters.'
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v1:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v1'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v1'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v1'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v1
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV1
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v1
+
+        SNMPv1 parameters type.
+
+        Represents snmpTargetParamsMPModel ''0'',
+
+        snmpTargetParamsSecurityModel ''1'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: post_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_params_params_v1_security_name'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v1/security-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v1_security_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v1_security_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v1_security_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v1_security_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV1SecurityName
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v1_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v2c:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v2c'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v2c'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v2c'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v2c
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV2c
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v2c
+
+        SNMPv2 community parameters type.
+
+        Represents snmpTargetParamsMPModel ''1'',
+
+        snmpTargetParamsSecurityModel ''2'', and
+
+        snmpTargetParamsSecurityLevel ''noAuthNoPriv''.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: PostIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: post_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_target_params_params_v2c_security_name'
+        required: true
+  /restconf/data/ietf-snmp:snmp/target-params={name}/v2c/security-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: put_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_target_params_params_v2c_security_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: patch_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_target_params_params_v2c_security_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_target_params_params_v2c_security_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: get_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: head_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: ''
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_target_params_params_v2c_security_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpTargetParamsParamsV2cSecurityName
+      description: 'OperationId: delete_ietf_snmp_snmp_target_params_params_v2c_security_name
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of
+
+        /snmp/community/security-name in a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxy
+      description: 'OperationId: put_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxy
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxy
+      description: 'OperationId: get_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxy
+      description: 'OperationId: head_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxy
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: PostIetfSnmpSnmpProxyType
+      description: 'OperationId: post_ietf_snmp_snmp_proxy_type
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_proxy_type'
+        required: true
+  /restconf/data/ietf-snmp:snmp/proxy:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PutListIetfSnmpSnmpProxy
+      description: 'OperationId: put_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_proxy'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpProxy
+      description: 'OperationId: patch_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_proxy'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: GetListIetfSnmpSnmpProxy
+      description: 'OperationId: get_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpProxy
+      description: 'OperationId: head_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_proxy
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpProxy
+      description: 'OperationId: delete_list_ietf_snmp_snmp_proxy
+
+        List of proxy parameters.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}/type:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyType
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_type
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_type'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyType
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_type
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_type'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_type'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyType
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_type
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyType
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_type
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_type
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyType
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_type
+
+        '
+  /restconf/data/ietf-snmp:snmp/proxy={name}/context-engine-id:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_context_engine_id'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_context_engine_id'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_context_engine_id'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_context_engine_id
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyContextEngineId
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_context_engine_id
+
+        '
+  /restconf/data/ietf-snmp:snmp/proxy={name}/context-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyContextName
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_context_name
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_context_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyContextName
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_context_name
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_context_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_context_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyContextName
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_context_name
+
+        '
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyContextName
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_context_name
+
+        '
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_context_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyContextName
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_context_name
+
+        '
+  /restconf/data/ietf-snmp:snmp/proxy={name}/target-params-in:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_target_params_in'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_target_params_in'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_target_params_in'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_target_params_in
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyTargetParamsIn
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_target_params_in
+
+        The name of a target parameters list entry.
+
+
+        Implementations MAY restrict the values of this
+
+        leaf to be one of the available values of
+
+        /snmp/target-params/name in a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}/single-target-out:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_single_target_out'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_single_target_out'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_single_target_out'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_single_target_out
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxySingleTargetOut
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_single_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/name in
+
+        a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/proxy={name}/multiple-target-out:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: PutIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: put_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_proxy_multiple_target_out'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: PatchIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: patch_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_proxy_multiple_target_out'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_proxy_multiple_target_out'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: GetIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: get_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: HeadIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: head_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Identifies the proxy parameter entry.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_proxy_multiple_target_out
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpProxyMultipleTargetOut
+      description: 'OperationId: delete_ietf_snmp_snmp_proxy_multiple_target_out
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+  /restconf/data/ietf-snmp:snmp/community={index}:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunity
+      description: 'OperationId: put_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunity
+      description: 'OperationId: patch_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunity
+      description: 'OperationId: get_ietf_snmp_snmp_community
+
+        List of communities.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunity
+      description: 'OperationId: head_ietf_snmp_snmp_community
+
+        List of communities.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunity
+      description: 'OperationId: delete_ietf_snmp_snmp_community
+
+        List of communities.'
+    post:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: PostIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: post_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_ietf_snmp_snmp_community_name_text_name'
+        required: true
+  /restconf/data/ietf-snmp:snmp/community:
+    put:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PutListIetfSnmpSnmpCommunity
+      description: 'OperationId: put_list_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_ietf_snmp_snmp_community'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: PatchListIetfSnmpSnmpCommunity
+      description: 'OperationId: patch_list_ietf_snmp_snmp_community
+
+        List of communities.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_ietf_snmp_snmp_community'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: GetListIetfSnmpSnmpCommunity
+      description: 'OperationId: get_list_ietf_snmp_snmp_community
+
+        List of communities.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: HeadListIetfSnmpSnmpCommunity
+      description: 'OperationId: head_list_ietf_snmp_snmp_community
+
+        List of communities.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_ietf_snmp_snmp_community
+      x-operationIdCamelCase: DeleteListIetfSnmpSnmpCommunity
+      description: 'OperationId: delete_list_ietf_snmp_snmp_community
+
+        List of communities.'
+  /restconf/data/ietf-snmp:snmp/community={index}/text-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: put_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_name_text_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: patch_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_name_text_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_name_text_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: get_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: head_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_name_text_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityNameTextName
+      description: 'OperationId: delete_ietf_snmp_snmp_community_name_text_name
+
+        A community name that can be represented as a
+
+        YANG string.'
+  /restconf/data/ietf-snmp:snmp/community={index}/binary-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: put_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_name_binary_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: patch_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_name_binary_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_name_binary_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: get_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: head_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_name_binary_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityNameBinaryName
+      description: 'OperationId: delete_ietf_snmp_snmp_community_name_binary_name
+
+        A community name represented as a binary value.'
+  /restconf/data/ietf-snmp:snmp/community={index}/security-name:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: put_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_security_name'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: patch_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_security_name'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_security_name'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: get_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: head_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_security_name
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunitySecurityName
+      description: 'OperationId: delete_ietf_snmp_snmp_community_security_name
+
+        The snmpCommunitySecurityName of this entry.'
+  /restconf/data/ietf-snmp:snmp/community={index}/engine-id:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: put_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_engine_id'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: patch_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_engine_id'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_engine_id'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: get_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: head_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_engine_id
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityEngineId
+      description: 'OperationId: delete_ietf_snmp_snmp_community_engine_id
+
+        If not set, the value of the local SNMP engine is
+
+        operationally used by the device.'
+  /restconf/data/ietf-snmp:snmp/community={index}/context:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityContext
+      description: 'OperationId: put_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_context'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityContext
+      description: 'OperationId: patch_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_context'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_context'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityContext
+      description: 'OperationId: get_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityContext
+      description: 'OperationId: head_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_context
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityContext
+      description: 'OperationId: delete_ietf_snmp_snmp_community_context
+
+        The context in which management information is accessed
+
+        when using the community string specified by this entry.'
+  /restconf/data/ietf-snmp:snmp/community={index}/target-tag:
+    put:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: PutIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: put_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_ietf_snmp_snmp_community_target_tag'
+        required: true
+    patch:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: PatchIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: patch_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_ietf_snmp_snmp_community_target_tag'
+        required: true
+    get:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_ietf_snmp_snmp_community_target_tag'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: GetIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: get_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    head:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: HeadIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: head_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+    delete:
+      tags:
+      - ietf-snmp
+      parameters:
+      - name: index
+        in: path
+        required: true
+        schema:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+        description: Index into the community list.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_ietf_snmp_snmp_community_target_tag
+      x-operationIdCamelCase: DeleteIetfSnmpSnmpCommunityTargetTag
+      description: 'OperationId: delete_ietf_snmp_snmp_community_target_tag
+
+        Used to limit access for this community to the specified
+
+        targets.
+
+
+        Implementations MAY restrict the values of this leaf
+
+        to be one of the available values of /snmp/target/tag in
+
+        a valid configuration.'
+components:
+  securitySchemes:
+    basic:
+      scheme: basic
+      type: http
+    bearer:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http
+  schemas:
+    ietf_snmp_snmp:
+      type: object
+      properties:
+        ietf-snmp:snmp:
+          type: object
+          properties:
+            target:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - target-params
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  tag:
+                    type: array
+                    items:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  timeout:
+                    default: 1500
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  retries:
+                    default: 3
+                    format: int32
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint8
+                  target-params:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  mms:
+                    oneOf:
+                    - enum:
+                      - unknown
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                    - format: int32
+                      maximum: 2147483647
+                      minimum: 484
+                      type: integer
+                      x-range: 484..max
+                      x-yang-type: int32
+                    default: 484
+                oneOf:
+                - type: object
+                  properties:
+                    udp:
+                      type: object
+                      properties:
+                        ip:
+                          oneOf:
+                          - maxLength: 18446744073709551615
+                            minLength: 0
+                            type: string
+                            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                            x-yang-type: string
+                          - maxLength: 18446744073709551615
+                            minLength: 0
+                            type: string
+                            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                              && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+                              && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+                            x-yang-type: string
+                        port:
+                          default: 162
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                          x-range: 0..65535
+                          x-yang-type: uint16
+                        prefix-length:
+                          format: int32
+                          maximum: 255
+                          minimum: 0
+                          type: integer
+                          x-yang-type: uint8
+                      required:
+                      - ip
+            target-params:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                oneOf:
+                - type: object
+                  properties:
+                    v1:
+                      type: object
+                      properties:
+                        security-name:
+                          maxLength: 255
+                          minLength: 0
+                          type: string
+                          x-length: 0..255
+                          x-yang-type: string
+                      required:
+                      - security-name
+                - type: object
+                  properties:
+                    v2c:
+                      type: object
+                      properties:
+                        security-name:
+                          maxLength: 255
+                          minLength: 0
+                          type: string
+                          x-length: 0..255
+                          x-yang-type: string
+                      required:
+                      - security-name
+            proxy:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                - context-engine-id
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  type:
+                    enum:
+                    - read
+                    - write
+                    - trap
+                    - inform
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  context-engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-params-in:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  single-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  multiple-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+            community:
+              type: array
+              items:
+                type: object
+                required:
+                - index
+                - security-name
+                properties:
+                  index:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context:
+                    default: ''
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-tag:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                oneOf:
+                - type: object
+                  properties:
+                    text-name:
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                - type: object
+                  properties:
+                    binary-name:
+                      format: binary
+                      type: string
+                      x-yang-type: binary
+    post_ietf_snmp_snmp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp'
+    put_ietf_snmp_snmp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp'
+    patch_ietf_snmp_snmp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp'
+    get_ietf_snmp_snmp:
+      type: object
+      properties:
+        ietf-snmp:snmp:
+          type: object
+          properties:
+            target:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - target-params
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  tag:
+                    type: array
+                    items:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  timeout:
+                    default: 1500
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  retries:
+                    default: 3
+                    format: int32
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint8
+                  target-params:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  mms:
+                    oneOf:
+                    - enum:
+                      - unknown
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                    - format: int32
+                      maximum: 2147483647
+                      minimum: 484
+                      type: integer
+                      x-range: 484..max
+                      x-yang-type: int32
+                    default: 484
+                oneOf:
+                - type: object
+                  properties:
+                    udp:
+                      type: object
+                      properties:
+                        ip:
+                          oneOf:
+                          - maxLength: 18446744073709551615
+                            minLength: 0
+                            type: string
+                            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                            x-yang-type: string
+                          - maxLength: 18446744073709551615
+                            minLength: 0
+                            type: string
+                            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                              && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+                              && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+                            x-yang-type: string
+                        port:
+                          default: 162
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                          x-range: 0..65535
+                          x-yang-type: uint16
+                        prefix-length:
+                          format: int32
+                          maximum: 255
+                          minimum: 0
+                          type: integer
+                          x-yang-type: uint8
+                      required:
+                      - ip
+            target-params:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                oneOf:
+                - type: object
+                  properties:
+                    v1:
+                      type: object
+                      properties:
+                        security-name:
+                          maxLength: 255
+                          minLength: 0
+                          type: string
+                          x-length: 0..255
+                          x-yang-type: string
+                      required:
+                      - security-name
+                - type: object
+                  properties:
+                    v2c:
+                      type: object
+                      properties:
+                        security-name:
+                          maxLength: 255
+                          minLength: 0
+                          type: string
+                          x-length: 0..255
+                          x-yang-type: string
+                      required:
+                      - security-name
+            proxy:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                - context-engine-id
+                properties:
+                  name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  type:
+                    enum:
+                    - read
+                    - write
+                    - trap
+                    - inform
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  context-engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-params-in:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  single-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  multiple-target-out:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+            community:
+              type: array
+              items:
+                type: object
+                required:
+                - index
+                - security-name
+                properties:
+                  index:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  security-name:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  engine-id:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  context:
+                    default: ''
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                  target-tag:
+                    maxLength: 255
+                    minLength: 0
+                    type: string
+                    x-length: 0..255
+                    x-yang-type: string
+                oneOf:
+                - type: object
+                  properties:
+                    text-name:
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                - type: object
+                  properties:
+                    binary-name:
+                      format: binary
+                      type: string
+                      x-yang-type: binary
+    ietf_snmp_snmp_target:
+      type: object
+      properties:
+        ietf-snmp:target:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - target-params
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              tag:
+                type: array
+                items:
+                  maxLength: 255
+                  minLength: 0
+                  type: string
+                  x-length: 0..255
+                  x-yang-type: string
+              timeout:
+                default: 1500
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+                x-yang-type: uint32
+              retries:
+                default: 3
+                format: int32
+                maximum: 255
+                minimum: 0
+                type: integer
+                x-yang-type: uint8
+              target-params:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              mms:
+                oneOf:
+                - enum:
+                  - unknown
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+                - format: int32
+                  maximum: 2147483647
+                  minimum: 484
+                  type: integer
+                  x-range: 484..max
+                  x-yang-type: int32
+                default: 484
+            oneOf:
+            - type: object
+              properties:
+                udp:
+                  type: object
+                  properties:
+                    ip:
+                      oneOf:
+                      - maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                        x-yang-type: string
+                      - maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                          && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+                          && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+                        x-yang-type: string
+                    port:
+                      default: 162
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                      x-range: 0..65535
+                      x-yang-type: uint16
+                    prefix-length:
+                      format: int32
+                      maximum: 255
+                      minimum: 0
+                      type: integer
+                      x-yang-type: uint8
+                  required:
+                  - ip
+    put_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    patch_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    get_ietf_snmp_snmp_target:
+      type: object
+      properties:
+        ietf-snmp:target:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - target-params
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              tag:
+                type: array
+                items:
+                  maxLength: 255
+                  minLength: 0
+                  type: string
+                  x-length: 0..255
+                  x-yang-type: string
+              timeout:
+                default: 1500
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+                x-yang-type: uint32
+              retries:
+                default: 3
+                format: int32
+                maximum: 255
+                minimum: 0
+                type: integer
+                x-yang-type: uint8
+              target-params:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              mms:
+                oneOf:
+                - enum:
+                  - unknown
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+                - format: int32
+                  maximum: 2147483647
+                  minimum: 484
+                  type: integer
+                  x-range: 484..max
+                  x-yang-type: int32
+                default: 484
+            oneOf:
+            - type: object
+              properties:
+                udp:
+                  type: object
+                  properties:
+                    ip:
+                      oneOf:
+                      - maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                        x-yang-type: string
+                      - maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                          && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+                          && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+                        x-yang-type: string
+                    port:
+                      default: 162
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                      x-range: 0..65535
+                      x-yang-type: uint16
+                    prefix-length:
+                      format: int32
+                      maximum: 255
+                      minimum: 0
+                      type: integer
+                      x-yang-type: uint8
+                  required:
+                  - ip
+    post_list_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    put_list_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    patch_list_ietf_snmp_snmp_target:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target'
+    ietf_snmp_snmp_target_transport_udp:
+      type: object
+      properties:
+        ietf-snmp:udp:
+          type: object
+          properties:
+            ip:
+              oneOf:
+              - maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                x-yang-type: string
+              - maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                  && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+                  && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+                x-yang-type: string
+            port:
+              default: 162
+              format: int32
+              maximum: 65535
+              minimum: 0
+              type: integer
+              x-range: 0..65535
+              x-yang-type: uint16
+            prefix-length:
+              format: int32
+              maximum: 255
+              minimum: 0
+              type: integer
+              x-yang-type: uint8
+          required:
+          - ip
+    post_ietf_snmp_snmp_target_transport_udp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_tag'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_timeout'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_retries'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_target_params'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_mms'
+    put_ietf_snmp_snmp_target_transport_udp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp'
+    patch_ietf_snmp_snmp_target_transport_udp:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp'
+    get_ietf_snmp_snmp_target_transport_udp:
+      type: object
+      properties:
+        ietf-snmp:udp:
+          type: object
+          properties:
+            ip:
+              oneOf:
+              - maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                x-yang-type: string
+              - maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+                  && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+                  && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+                x-yang-type: string
+            port:
+              default: 162
+              format: int32
+              maximum: 65535
+              minimum: 0
+              type: integer
+              x-range: 0..65535
+              x-yang-type: uint16
+            prefix-length:
+              format: int32
+              maximum: 255
+              minimum: 0
+              type: integer
+              x-yang-type: uint8
+          required:
+          - ip
+    ietf_snmp_snmp_target_transport_udp_ip:
+      type: object
+      properties:
+        ietf-snmp:ip:
+          oneOf:
+          - maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+            x-yang-type: string
+          - maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+              && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+              && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+            x-yang-type: string
+    post_ietf_snmp_snmp_target_transport_udp_ip:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_ip'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_port'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_prefix_length'
+    put_ietf_snmp_snmp_target_transport_udp_ip:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_ip'
+    patch_ietf_snmp_snmp_target_transport_udp_ip:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_ip'
+    get_ietf_snmp_snmp_target_transport_udp_ip:
+      type: object
+      properties:
+        ietf-snmp:ip:
+          oneOf:
+          - maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+            x-yang-type: string
+          - maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?
+              && ((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?
+              && (([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?
+            x-yang-type: string
+    ietf_snmp_snmp_target_transport_udp_port:
+      type: object
+      properties:
+        ietf-snmp:port:
+          default: 162
+          format: int32
+          maximum: 65535
+          minimum: 0
+          type: integer
+          x-range: 0..65535
+          x-yang-type: uint16
+    put_ietf_snmp_snmp_target_transport_udp_port:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_port'
+    patch_ietf_snmp_snmp_target_transport_udp_port:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_port'
+    get_ietf_snmp_snmp_target_transport_udp_port:
+      type: object
+      properties:
+        ietf-snmp:port:
+          default: 162
+          format: int32
+          maximum: 65535
+          minimum: 0
+          type: integer
+          x-range: 0..65535
+          x-yang-type: uint16
+    ietf_snmp_snmp_target_transport_udp_prefix_length:
+      type: object
+      properties:
+        ietf-snmp:prefix-length:
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    put_ietf_snmp_snmp_target_transport_udp_prefix_length:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_prefix_length'
+    patch_ietf_snmp_snmp_target_transport_udp_prefix_length:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_transport_udp_prefix_length'
+    get_ietf_snmp_snmp_target_transport_udp_prefix_length:
+      type: object
+      properties:
+        ietf-snmp:prefix-length:
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    ietf_snmp_snmp_target_tag:
+      type: object
+      properties:
+        ietf-snmp:tag:
+          type: array
+          items:
+            maxLength: 255
+            minLength: 0
+            type: string
+            x-length: 0..255
+            x-yang-type: string
+    put_ietf_snmp_snmp_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_tag'
+    patch_ietf_snmp_snmp_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_tag'
+    get_ietf_snmp_snmp_target_tag:
+      type: object
+      properties:
+        ietf-snmp:tag:
+          type: array
+          items:
+            maxLength: 255
+            minLength: 0
+            type: string
+            x-length: 0..255
+            x-yang-type: string
+    ietf_snmp_snmp_target_timeout:
+      type: object
+      properties:
+        ietf-snmp:timeout:
+          default: 1500
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    put_ietf_snmp_snmp_target_timeout:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_timeout'
+    patch_ietf_snmp_snmp_target_timeout:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_timeout'
+    get_ietf_snmp_snmp_target_timeout:
+      type: object
+      properties:
+        ietf-snmp:timeout:
+          default: 1500
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    ietf_snmp_snmp_target_retries:
+      type: object
+      properties:
+        ietf-snmp:retries:
+          default: 3
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    put_ietf_snmp_snmp_target_retries:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_retries'
+    patch_ietf_snmp_snmp_target_retries:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_retries'
+    get_ietf_snmp_snmp_target_retries:
+      type: object
+      properties:
+        ietf-snmp:retries:
+          default: 3
+          format: int32
+          maximum: 255
+          minimum: 0
+          type: integer
+          x-yang-type: uint8
+    ietf_snmp_snmp_target_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_target_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_target_params'
+    patch_ietf_snmp_snmp_target_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_target_params'
+    get_ietf_snmp_snmp_target_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_target_mms:
+      type: object
+      properties:
+        ietf-snmp:mms:
+          oneOf:
+          - enum:
+            - unknown
+            maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-yang-type: string
+          - format: int32
+            maximum: 2147483647
+            minimum: 484
+            type: integer
+            x-range: 484..max
+            x-yang-type: int32
+          default: 484
+    put_ietf_snmp_snmp_target_mms:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_mms'
+    patch_ietf_snmp_snmp_target_mms:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_mms'
+    get_ietf_snmp_snmp_target_mms:
+      type: object
+      properties:
+        ietf-snmp:mms:
+          oneOf:
+          - enum:
+            - unknown
+            maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-yang-type: string
+          - format: int32
+            maximum: 2147483647
+            minimum: 484
+            type: integer
+            x-range: 484..max
+            x-yang-type: int32
+          default: 484
+    ietf_snmp_snmp_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+            oneOf:
+            - type: object
+              properties:
+                v1:
+                  type: object
+                  properties:
+                    security-name:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  required:
+                  - security-name
+            - type: object
+              properties:
+                v2c:
+                  type: object
+                  properties:
+                    security-name:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  required:
+                  - security-name
+    put_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    patch_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    get_ietf_snmp_snmp_target_params:
+      type: object
+      properties:
+        ietf-snmp:target-params:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+            oneOf:
+            - type: object
+              properties:
+                v1:
+                  type: object
+                  properties:
+                    security-name:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  required:
+                  - security-name
+            - type: object
+              properties:
+                v2c:
+                  type: object
+                  properties:
+                    security-name:
+                      maxLength: 255
+                      minLength: 0
+                      type: string
+                      x-length: 0..255
+                      x-yang-type: string
+                  required:
+                  - security-name
+    put_list_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    patch_list_ietf_snmp_snmp_target_params:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params'
+    ietf_snmp_snmp_target_params_params_v1:
+      type: object
+      properties:
+        ietf-snmp:v1:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    post_ietf_snmp_snmp_target_params_params_v1:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c'
+    put_ietf_snmp_snmp_target_params_params_v1:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1'
+    patch_ietf_snmp_snmp_target_params_params_v1:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1'
+    get_ietf_snmp_snmp_target_params_params_v1:
+      type: object
+      properties:
+        ietf-snmp:v1:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    ietf_snmp_snmp_target_params_params_v1_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    post_ietf_snmp_snmp_target_params_params_v1_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1_security_name'
+    put_ietf_snmp_snmp_target_params_params_v1_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1_security_name'
+    patch_ietf_snmp_snmp_target_params_params_v1_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v1_security_name'
+    get_ietf_snmp_snmp_target_params_params_v1_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_target_params_params_v2c:
+      type: object
+      properties:
+        ietf-snmp:v2c:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    put_ietf_snmp_snmp_target_params_params_v2c:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c'
+    patch_ietf_snmp_snmp_target_params_params_v2c:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c'
+    get_ietf_snmp_snmp_target_params_params_v2c:
+      type: object
+      properties:
+        ietf-snmp:v2c:
+          type: object
+          properties:
+            security-name:
+              maxLength: 255
+              minLength: 0
+              type: string
+              x-length: 0..255
+              x-yang-type: string
+          required:
+          - security-name
+    ietf_snmp_snmp_target_params_params_v2c_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    post_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c_security_name'
+    put_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c_security_name'
+    patch_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_target_params_params_v2c_security_name'
+    get_ietf_snmp_snmp_target_params_params_v2c_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy:
+      type: object
+      properties:
+        ietf-snmp:proxy:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            - context-engine-id
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              type:
+                enum:
+                - read
+                - write
+                - trap
+                - inform
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              context-engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-params-in:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              single-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              multiple-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+    put_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    patch_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    get_ietf_snmp_snmp_proxy:
+      type: object
+      properties:
+        ietf-snmp:proxy:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            - context-engine-id
+            properties:
+              name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              type:
+                enum:
+                - read
+                - write
+                - trap
+                - inform
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              context-engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-params-in:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              single-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              multiple-target-out:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+    put_list_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    patch_list_ietf_snmp_snmp_proxy:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy'
+    ietf_snmp_snmp_proxy_type:
+      type: object
+      properties:
+        ietf-snmp:type:
+          enum:
+          - read
+          - write
+          - trap
+          - inform
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    post_ietf_snmp_snmp_proxy_type:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_type'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_engine_id'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_target_params_in'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_single_target_out'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_multiple_target_out'
+    put_ietf_snmp_snmp_proxy_type:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_type'
+    patch_ietf_snmp_snmp_proxy_type:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_type'
+    get_ietf_snmp_snmp_proxy_type:
+      type: object
+      properties:
+        ietf-snmp:type:
+          enum:
+          - read
+          - write
+          - trap
+          - inform
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_context_engine_id:
+      type: object
+      properties:
+        ietf-snmp:context-engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_context_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_engine_id'
+    patch_ietf_snmp_snmp_proxy_context_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_engine_id'
+    get_ietf_snmp_snmp_proxy_context_engine_id:
+      type: object
+      properties:
+        ietf-snmp:context-engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_context_name:
+      type: object
+      properties:
+        ietf-snmp:context-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_context_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_name'
+    patch_ietf_snmp_snmp_proxy_context_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_context_name'
+    get_ietf_snmp_snmp_proxy_context_name:
+      type: object
+      properties:
+        ietf-snmp:context-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_target_params_in:
+      type: object
+      properties:
+        ietf-snmp:target-params-in:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_target_params_in:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_target_params_in'
+    patch_ietf_snmp_snmp_proxy_target_params_in:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_target_params_in'
+    get_ietf_snmp_snmp_proxy_target_params_in:
+      type: object
+      properties:
+        ietf-snmp:target-params-in:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_single_target_out:
+      type: object
+      properties:
+        ietf-snmp:single-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_single_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_single_target_out'
+    patch_ietf_snmp_snmp_proxy_single_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_single_target_out'
+    get_ietf_snmp_snmp_proxy_single_target_out:
+      type: object
+      properties:
+        ietf-snmp:single-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_proxy_multiple_target_out:
+      type: object
+      properties:
+        ietf-snmp:multiple-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_proxy_multiple_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_multiple_target_out'
+    patch_ietf_snmp_snmp_proxy_multiple_target_out:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_proxy_multiple_target_out'
+    get_ietf_snmp_snmp_proxy_multiple_target_out:
+      type: object
+      properties:
+        ietf-snmp:multiple-target-out:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_community:
+      type: object
+      properties:
+        ietf-snmp:community:
+          type: array
+          items:
+            type: object
+            required:
+            - index
+            - security-name
+            properties:
+              index:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              security-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context:
+                default: ''
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-tag:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+            oneOf:
+            - type: object
+              properties:
+                text-name:
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+            - type: object
+              properties:
+                binary-name:
+                  format: binary
+                  type: string
+                  x-yang-type: binary
+    put_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    patch_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    get_ietf_snmp_snmp_community:
+      type: object
+      properties:
+        ietf-snmp:community:
+          type: array
+          items:
+            type: object
+            required:
+            - index
+            - security-name
+            properties:
+              index:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              security-name:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              engine-id:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              context:
+                default: ''
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+              target-tag:
+                maxLength: 255
+                minLength: 0
+                type: string
+                x-length: 0..255
+                x-yang-type: string
+            oneOf:
+            - type: object
+              properties:
+                text-name:
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+            - type: object
+              properties:
+                binary-name:
+                  format: binary
+                  type: string
+                  x-yang-type: binary
+    put_list_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    patch_list_ietf_snmp_snmp_community:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community'
+    ietf_snmp_snmp_community_name_text_name:
+      type: object
+      properties:
+        ietf-snmp:text-name:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    post_ietf_snmp_snmp_community_name_text_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_text_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_binary_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_security_name'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_engine_id'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_context'
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_target_tag'
+    put_ietf_snmp_snmp_community_name_text_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_text_name'
+    patch_ietf_snmp_snmp_community_name_text_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_text_name'
+    get_ietf_snmp_snmp_community_name_text_name:
+      type: object
+      properties:
+        ietf-snmp:text-name:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    ietf_snmp_snmp_community_name_binary_name:
+      type: object
+      properties:
+        ietf-snmp:binary-name:
+          format: binary
+          type: string
+          x-yang-type: binary
+    put_ietf_snmp_snmp_community_name_binary_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_binary_name'
+    patch_ietf_snmp_snmp_community_name_binary_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_name_binary_name'
+    get_ietf_snmp_snmp_community_name_binary_name:
+      type: object
+      properties:
+        ietf-snmp:binary-name:
+          format: binary
+          type: string
+          x-yang-type: binary
+    ietf_snmp_snmp_community_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_security_name'
+    patch_ietf_snmp_snmp_community_security_name:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_security_name'
+    get_ietf_snmp_snmp_community_security_name:
+      type: object
+      properties:
+        ietf-snmp:security-name:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_community_engine_id:
+      type: object
+      properties:
+        ietf-snmp:engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_engine_id'
+    patch_ietf_snmp_snmp_community_engine_id:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_engine_id'
+    get_ietf_snmp_snmp_community_engine_id:
+      type: object
+      properties:
+        ietf-snmp:engine-id:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    ietf_snmp_snmp_community_context:
+      type: object
+      properties:
+        ietf-snmp:context:
+          default: ''
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_context:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_context'
+    patch_ietf_snmp_snmp_community_context:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_context'
+    get_ietf_snmp_snmp_community_context:
+      type: object
+      properties:
+        ietf-snmp:context:
+          default: ''
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    ietf_snmp_snmp_community_target_tag:
+      type: object
+      properties:
+        ietf-snmp:target-tag:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string
+    put_ietf_snmp_snmp_community_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_target_tag'
+    patch_ietf_snmp_snmp_community_target_tag:
+      allOf:
+      - $ref: '#/components/schemas/ietf_snmp_snmp_community_target_tag'
+    get_ietf_snmp_snmp_community_target_tag:
+      type: object
+      properties:
+        ietf-snmp:target-tag:
+          maxLength: 255
+          minLength: 0
+          type: string
+          x-length: 0..255
+          x-yang-type: string

--- a/tools/openapi_tests/ietf-yang-types.yang
+++ b/tools/openapi_tests/ietf-yang-types.yang
@@ -1,0 +1,474 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/tools/openapi_tests/test-data-nodes.yang
+++ b/tools/openapi_tests/test-data-nodes.yang
@@ -1,0 +1,1092 @@
+module test-data-nodes {
+  yang-version 1.1;
+  namespace "urn:test:params:xml:ns:yang:test-data-nodes";
+  prefix if;
+
+  import test-yang-types {
+    prefix yang;
+  }
+
+    organization "Example, Inc.";
+    contact "support at example.com";
+
+  description
+    "This module contains a collection of YANG definitions for
+     managing network interfaces.";
+
+  revision 2020-04-20 {
+    description
+      "Initial version.";
+  }
+
+  /*
+   * Typedefs
+   */
+
+  typedef interface-ref {
+    type leafref {
+      path "/if:interfaces/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       interfaces.";
+  }
+
+  /*
+   * Identities
+   */
+
+  identity interface-type {
+    description
+      "Base identity from which specific interface types are
+       derived.";
+  }
+
+  /*
+   * Features
+   */
+
+  feature arbitrary-names {
+    description
+      "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+  }
+  feature pre-provisioning {
+    description
+      "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+  }
+  feature if-mib {
+    description
+      "This feature indicates that the device implements
+       the IF-MIB.";
+    reference
+      "RFC 2863: The Interfaces Group MIB";
+  }
+
+  /*
+   * Data nodes
+   */
+
+  container interfaces {
+    description
+      "Interface parameters.";
+
+    list interface {
+      key "name";
+
+      description
+        "The list of interfaces on the device.
+
+         The status of an interface is available in this list in the
+         operational state.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the operational
+         state.  If the configuration of a user-controlled interface
+         cannot be used by the system, the configured interface is
+         not instantiated in the operational state.
+
+         System-controlled interfaces created by the system are
+         always present in this list in the operational state,
+         whether or not they are configured.";
+
+     leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           operational state, the server MAY reject the request if
+           the implementation does not support pre-provisioning of
+           interfaces or if the name refers to an interface that can
+           never exist in the system.  A Network Configuration
+           Protocol (NETCONF) server MUST reply with an rpc-error
+           with the error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           operational state.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf description {
+        type string;
+        description
+          "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           configuration.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAlias";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the intended configuration to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+           Changes in this leaf in the intended configuration are
+           reflected in ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf link-up-down-trap-enable {
+        if-feature if-mib;
+        type enumeration {
+          enum enabled {
+            value 1;
+            description
+              "The device will generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+          enum disabled {
+            value 2;
+            description
+              "The device will not generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+        }
+        description
+          "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifLinkUpDownTrapEnable";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        config false;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        config false;
+        mandatory true;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        config false;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        config false;
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+      container statistics {
+        config false;
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+        leaf out-octets {
+          type yang:counter64;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+
+    }
+  }
+
+  /*
+   * Legacy typedefs
+   */
+
+  typedef interface-state-ref {
+    type leafref {
+      path "/if:interfaces-state/if:interface/if:name";
+    }
+    status deprecated;
+    description
+      "This type is used by data models that need to reference
+       the operationally present interfaces.";
+  }
+
+  /*
+   * Legacy operational state data nodes
+   */
+
+  container interfaces-state {
+    config false;
+    status deprecated;
+    description
+      "Data nodes for the operational state of interfaces.";
+
+    list interface {
+      key "name";
+      status deprecated;
+
+      description
+        "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether or not they are
+         configured.";
+
+      leaf name {
+        type string;
+        status deprecated;
+        description
+          "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The type of the interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        status deprecated;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        status deprecated;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        status deprecated;
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+      container statistics {
+        status deprecated;
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          status deprecated;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+        leaf out-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+}

--- a/tools/openapi_tests/test-data-nodes.yang.expect
+++ b/tools/openapi_tests/test-data-nodes.yang.expect
@@ -1,0 +1,12727 @@
+openapi: 3.0.1
+info:
+  description: Network Management Open APIs for SONiC
+  version: 1.0.0
+  title: Sonic Network Management RESTCONF APIs
+servers:
+- url: https://
+security:
+- basic: []
+- bearer: []
+tags:
+- name: test-data-nodes
+  description: Operations for test-data-nodes
+paths:
+  /restconf/data/test-data-nodes:interfaces:
+    put:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_test_data_nodes_interfaces
+      x-operationIdCamelCase: PutTestDataNodesInterfaces
+      description: 'OperationId: put_test_data_nodes_interfaces
+
+        Interface parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_test_data_nodes_interfaces'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_test_data_nodes_interfaces
+      x-operationIdCamelCase: PatchTestDataNodesInterfaces
+      description: 'OperationId: patch_test_data_nodes_interfaces
+
+        Interface parameters.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_test_data_nodes_interfaces'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_test_data_nodes_interfaces
+      x-operationIdCamelCase: GetTestDataNodesInterfaces
+      description: 'OperationId: get_test_data_nodes_interfaces
+
+        Interface parameters.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_test_data_nodes_interfaces
+      x-operationIdCamelCase: HeadTestDataNodesInterfaces
+      description: 'OperationId: head_test_data_nodes_interfaces
+
+        Interface parameters.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_test_data_nodes_interfaces
+      x-operationIdCamelCase: DeleteTestDataNodesInterfaces
+      description: 'OperationId: delete_test_data_nodes_interfaces
+
+        Interface parameters.'
+    post:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_list_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: PostListTestDataNodesInterfacesInterface
+      description: 'OperationId: post_list_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_list_test_data_nodes_interfaces_interface'
+        required: true
+  /restconf/data/test-data-nodes:interfaces/interface={name}:
+    put:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: PutTestDataNodesInterfacesInterface
+      description: 'OperationId: put_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_test_data_nodes_interfaces_interface'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: PatchTestDataNodesInterfacesInterface
+      description: 'OperationId: patch_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_test_data_nodes_interfaces_interface'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterface
+      description: 'OperationId: get_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterface
+      description: 'OperationId: head_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: DeleteTestDataNodesInterfacesInterface
+      description: 'OperationId: delete_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+    post:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: post_test_data_nodes_interfaces_interface_description
+      x-operationIdCamelCase: PostTestDataNodesInterfacesInterfaceDescription
+      description: 'OperationId: post_test_data_nodes_interfaces_interface_description
+
+        A textual description of the interface.
+
+
+        A server implementation MAY map this leaf to the ifAlias
+
+        MIB object.  Such an implementation needs to use some
+
+        mechanism to handle the differences in size and characters
+
+        allowed between this leaf and ifAlias.  The definition of
+
+        such a mechanism is outside the scope of this document.
+
+
+        Since ifAlias is defined to be stored in non-volatile
+
+        storage, the MIB implementation MUST map ifAlias to the
+
+        value of ''description'' in the persistently stored
+
+        configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/post_test_data_nodes_interfaces_interface_description'
+        required: true
+  /restconf/data/test-data-nodes:interfaces/interface:
+    put:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_list_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: PutListTestDataNodesInterfacesInterface
+      description: 'OperationId: put_list_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_list_test_data_nodes_interfaces_interface'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_list_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: PatchListTestDataNodesInterfacesInterface
+      description: 'OperationId: patch_list_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_list_test_data_nodes_interfaces_interface'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_list_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: GetListTestDataNodesInterfacesInterface
+      description: 'OperationId: get_list_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_list_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: HeadListTestDataNodesInterfacesInterface
+      description: 'OperationId: head_list_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_list_test_data_nodes_interfaces_interface
+      x-operationIdCamelCase: DeleteListTestDataNodesInterfacesInterface
+      description: 'OperationId: delete_list_test_data_nodes_interfaces_interface
+
+        The list of interfaces on the device.
+
+
+        The status of an interface is available in this list in the
+
+        operational state.  If the configuration of a
+
+        system-controlled interface cannot be used by the system
+
+        (e.g., the interface hardware present does not match the
+
+        interface type), then the configuration is not applied to
+
+        the system-controlled interface shown in the operational
+
+        state.  If the configuration of a user-controlled interface
+
+        cannot be used by the system, the configured interface is
+
+        not instantiated in the operational state.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list in the operational state,
+
+        whether or not they are configured.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/description:
+    put:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_test_data_nodes_interfaces_interface_description
+      x-operationIdCamelCase: PutTestDataNodesInterfacesInterfaceDescription
+      description: 'OperationId: put_test_data_nodes_interfaces_interface_description
+
+        A textual description of the interface.
+
+
+        A server implementation MAY map this leaf to the ifAlias
+
+        MIB object.  Such an implementation needs to use some
+
+        mechanism to handle the differences in size and characters
+
+        allowed between this leaf and ifAlias.  The definition of
+
+        such a mechanism is outside the scope of this document.
+
+
+        Since ifAlias is defined to be stored in non-volatile
+
+        storage, the MIB implementation MUST map ifAlias to the
+
+        value of ''description'' in the persistently stored
+
+        configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_test_data_nodes_interfaces_interface_description'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_test_data_nodes_interfaces_interface_description
+      x-operationIdCamelCase: PatchTestDataNodesInterfacesInterfaceDescription
+      description: 'OperationId: patch_test_data_nodes_interfaces_interface_description
+
+        A textual description of the interface.
+
+
+        A server implementation MAY map this leaf to the ifAlias
+
+        MIB object.  Such an implementation needs to use some
+
+        mechanism to handle the differences in size and characters
+
+        allowed between this leaf and ifAlias.  The definition of
+
+        such a mechanism is outside the scope of this document.
+
+
+        Since ifAlias is defined to be stored in non-volatile
+
+        storage, the MIB implementation MUST map ifAlias to the
+
+        value of ''description'' in the persistently stored
+
+        configuration.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_test_data_nodes_interfaces_interface_description'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_description'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_test_data_nodes_interfaces_interface_description
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceDescription
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_description
+
+        A textual description of the interface.
+
+
+        A server implementation MAY map this leaf to the ifAlias
+
+        MIB object.  Such an implementation needs to use some
+
+        mechanism to handle the differences in size and characters
+
+        allowed between this leaf and ifAlias.  The definition of
+
+        such a mechanism is outside the scope of this document.
+
+
+        Since ifAlias is defined to be stored in non-volatile
+
+        storage, the MIB implementation MUST map ifAlias to the
+
+        value of ''description'' in the persistently stored
+
+        configuration.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_test_data_nodes_interfaces_interface_description
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceDescription
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_description
+
+        A textual description of the interface.
+
+
+        A server implementation MAY map this leaf to the ifAlias
+
+        MIB object.  Such an implementation needs to use some
+
+        mechanism to handle the differences in size and characters
+
+        allowed between this leaf and ifAlias.  The definition of
+
+        such a mechanism is outside the scope of this document.
+
+
+        Since ifAlias is defined to be stored in non-volatile
+
+        storage, the MIB implementation MUST map ifAlias to the
+
+        value of ''description'' in the persistently stored
+
+        configuration.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_test_data_nodes_interfaces_interface_description
+      x-operationIdCamelCase: DeleteTestDataNodesInterfacesInterfaceDescription
+      description: 'OperationId: delete_test_data_nodes_interfaces_interface_description
+
+        A textual description of the interface.
+
+
+        A server implementation MAY map this leaf to the ifAlias
+
+        MIB object.  Such an implementation needs to use some
+
+        mechanism to handle the differences in size and characters
+
+        allowed between this leaf and ifAlias.  The definition of
+
+        such a mechanism is outside the scope of this document.
+
+
+        Since ifAlias is defined to be stored in non-volatile
+
+        storage, the MIB implementation MUST map ifAlias to the
+
+        value of ''description'' in the persistently stored
+
+        configuration.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/type:
+    put:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_test_data_nodes_interfaces_interface_type
+      x-operationIdCamelCase: PutTestDataNodesInterfacesInterfaceType
+      description: 'OperationId: put_test_data_nodes_interfaces_interface_type
+
+        The type of the interface.
+
+
+        When an interface entry is created, a server MAY
+
+        initialize the type leaf with a valid value, e.g., if it
+
+        is possible to derive the type from the name of the
+
+        interface.
+
+
+        If a client tries to set the type of an interface to a
+
+        value that can never be used by the system, e.g., if the
+
+        type is not supported or if the type does not match the
+
+        name of the interface, the server MUST reject the request.
+
+        A NETCONF server MUST reply with an rpc-error with the
+
+        error-tag ''invalid-value'' in this case.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_test_data_nodes_interfaces_interface_type'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_test_data_nodes_interfaces_interface_type
+      x-operationIdCamelCase: PatchTestDataNodesInterfacesInterfaceType
+      description: 'OperationId: patch_test_data_nodes_interfaces_interface_type
+
+        The type of the interface.
+
+
+        When an interface entry is created, a server MAY
+
+        initialize the type leaf with a valid value, e.g., if it
+
+        is possible to derive the type from the name of the
+
+        interface.
+
+
+        If a client tries to set the type of an interface to a
+
+        value that can never be used by the system, e.g., if the
+
+        type is not supported or if the type does not match the
+
+        name of the interface, the server MUST reject the request.
+
+        A NETCONF server MUST reply with an rpc-error with the
+
+        error-tag ''invalid-value'' in this case.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_test_data_nodes_interfaces_interface_type'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_type'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_test_data_nodes_interfaces_interface_type
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceType
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_type
+
+        The type of the interface.
+
+
+        When an interface entry is created, a server MAY
+
+        initialize the type leaf with a valid value, e.g., if it
+
+        is possible to derive the type from the name of the
+
+        interface.
+
+
+        If a client tries to set the type of an interface to a
+
+        value that can never be used by the system, e.g., if the
+
+        type is not supported or if the type does not match the
+
+        name of the interface, the server MUST reject the request.
+
+        A NETCONF server MUST reply with an rpc-error with the
+
+        error-tag ''invalid-value'' in this case.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_test_data_nodes_interfaces_interface_type
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceType
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_type
+
+        The type of the interface.
+
+
+        When an interface entry is created, a server MAY
+
+        initialize the type leaf with a valid value, e.g., if it
+
+        is possible to derive the type from the name of the
+
+        interface.
+
+
+        If a client tries to set the type of an interface to a
+
+        value that can never be used by the system, e.g., if the
+
+        type is not supported or if the type does not match the
+
+        name of the interface, the server MUST reject the request.
+
+        A NETCONF server MUST reply with an rpc-error with the
+
+        error-tag ''invalid-value'' in this case.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_test_data_nodes_interfaces_interface_type
+      x-operationIdCamelCase: DeleteTestDataNodesInterfacesInterfaceType
+      description: 'OperationId: delete_test_data_nodes_interfaces_interface_type
+
+        The type of the interface.
+
+
+        When an interface entry is created, a server MAY
+
+        initialize the type leaf with a valid value, e.g., if it
+
+        is possible to derive the type from the name of the
+
+        interface.
+
+
+        If a client tries to set the type of an interface to a
+
+        value that can never be used by the system, e.g., if the
+
+        type is not supported or if the type does not match the
+
+        name of the interface, the server MUST reject the request.
+
+        A NETCONF server MUST reply with an rpc-error with the
+
+        error-tag ''invalid-value'' in this case.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/enabled:
+    put:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_test_data_nodes_interfaces_interface_enabled
+      x-operationIdCamelCase: PutTestDataNodesInterfacesInterfaceEnabled
+      description: 'OperationId: put_test_data_nodes_interfaces_interface_enabled
+
+        This leaf contains the configured, desired state of the
+
+        interface.
+
+
+        Systems that implement the IF-MIB use the value of this
+
+        leaf in the intended configuration to set
+
+        IF-MIB.ifAdminStatus to ''up'' or ''down'' after an ifEntry
+
+        has been initialized, as described in RFC 2863.
+
+
+        Changes in this leaf in the intended configuration are
+
+        reflected in ifAdminStatus.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_test_data_nodes_interfaces_interface_enabled'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_test_data_nodes_interfaces_interface_enabled
+      x-operationIdCamelCase: PatchTestDataNodesInterfacesInterfaceEnabled
+      description: 'OperationId: patch_test_data_nodes_interfaces_interface_enabled
+
+        This leaf contains the configured, desired state of the
+
+        interface.
+
+
+        Systems that implement the IF-MIB use the value of this
+
+        leaf in the intended configuration to set
+
+        IF-MIB.ifAdminStatus to ''up'' or ''down'' after an ifEntry
+
+        has been initialized, as described in RFC 2863.
+
+
+        Changes in this leaf in the intended configuration are
+
+        reflected in ifAdminStatus.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_test_data_nodes_interfaces_interface_enabled'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_enabled'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_test_data_nodes_interfaces_interface_enabled
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceEnabled
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_enabled
+
+        This leaf contains the configured, desired state of the
+
+        interface.
+
+
+        Systems that implement the IF-MIB use the value of this
+
+        leaf in the intended configuration to set
+
+        IF-MIB.ifAdminStatus to ''up'' or ''down'' after an ifEntry
+
+        has been initialized, as described in RFC 2863.
+
+
+        Changes in this leaf in the intended configuration are
+
+        reflected in ifAdminStatus.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_test_data_nodes_interfaces_interface_enabled
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceEnabled
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_enabled
+
+        This leaf contains the configured, desired state of the
+
+        interface.
+
+
+        Systems that implement the IF-MIB use the value of this
+
+        leaf in the intended configuration to set
+
+        IF-MIB.ifAdminStatus to ''up'' or ''down'' after an ifEntry
+
+        has been initialized, as described in RFC 2863.
+
+
+        Changes in this leaf in the intended configuration are
+
+        reflected in ifAdminStatus.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_test_data_nodes_interfaces_interface_enabled
+      x-operationIdCamelCase: DeleteTestDataNodesInterfacesInterfaceEnabled
+      description: 'OperationId: delete_test_data_nodes_interfaces_interface_enabled
+
+        This leaf contains the configured, desired state of the
+
+        interface.
+
+
+        Systems that implement the IF-MIB use the value of this
+
+        leaf in the intended configuration to set
+
+        IF-MIB.ifAdminStatus to ''up'' or ''down'' after an ifEntry
+
+        has been initialized, as described in RFC 2863.
+
+
+        Changes in this leaf in the intended configuration are
+
+        reflected in ifAdminStatus.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/link-up-down-trap-enable:
+    put:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '201':
+          description: Created
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: put_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+      x-operationIdCamelCase: PutTestDataNodesInterfacesInterfaceLinkUpDownTrapEnable
+      description: 'OperationId: put_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+
+        Controls whether linkUp/linkDown SNMP notifications
+
+        should be generated for this interface.
+
+
+        If this node is not configured, the value ''enabled'' is
+
+        operationally used by the server for interfaces that do
+
+        not operate on top of any other interface (i.e., there are
+
+        no ''lower-layer-if'' entries), and ''disabled'' otherwise.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/put_test_data_nodes_interfaces_interface_link_up_down_trap_enable'
+        required: true
+    patch:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '409':
+          description: Conflict
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: patch_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+      x-operationIdCamelCase: PatchTestDataNodesInterfacesInterfaceLinkUpDownTrapEnable
+      description: 'OperationId: patch_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+
+        Controls whether linkUp/linkDown SNMP notifications
+
+        should be generated for this interface.
+
+
+        If this node is not configured, the value ''enabled'' is
+
+        operationally used by the server for interfaces that do
+
+        not operate on top of any other interface (i.e., there are
+
+        no ''lower-layer-if'' entries), and ''disabled'' otherwise.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/patch_test_data_nodes_interfaces_interface_link_up_down_trap_enable'
+        required: true
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_link_up_down_trap_enable'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: get_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceLinkUpDownTrapEnable
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+
+        Controls whether linkUp/linkDown SNMP notifications
+
+        should be generated for this interface.
+
+
+        If this node is not configured, the value ''enabled'' is
+
+        operationally used by the server for interfaces that do
+
+        not operate on top of any other interface (i.e., there are
+
+        no ''lower-layer-if'' entries), and ''disabled'' otherwise.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: head_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceLinkUpDownTrapEnable
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+
+        Controls whether linkUp/linkDown SNMP notifications
+
+        should be generated for this interface.
+
+
+        If this node is not configured, the value ''enabled'' is
+
+        operationally used by the server for interfaces that do
+
+        not operate on top of any other interface (i.e., there are
+
+        no ''lower-layer-if'' entries), and ''disabled'' otherwise.'
+    delete:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      operationId: delete_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+      x-operationIdCamelCase: DeleteTestDataNodesInterfacesInterfaceLinkUpDownTrapEnable
+      description: 'OperationId: delete_test_data_nodes_interfaces_interface_link_up_down_trap_enable
+
+        Controls whether linkUp/linkDown SNMP notifications
+
+        should be generated for this interface.
+
+
+        If this node is not configured, the value ''enabled'' is
+
+        operationally used by the server for interfaces that do
+
+        not operate on top of any other interface (i.e., there are
+
+        no ''lower-layer-if'' entries), and ''disabled'' otherwise.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/admin-status:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_admin_status'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_admin_status
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceAdminStatus
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_admin_status
+
+        The desired state of the interface.
+
+
+        This leaf has the same read semantics as ifAdminStatus.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_admin_status
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceAdminStatus
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_admin_status
+
+        The desired state of the interface.
+
+
+        This leaf has the same read semantics as ifAdminStatus.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/oper-status:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_oper_status'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_oper_status
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceOperStatus
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_oper_status
+
+        The current operational state of the interface.
+
+
+        This leaf has the same semantics as ifOperStatus.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_oper_status
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceOperStatus
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_oper_status
+
+        The current operational state of the interface.
+
+
+        This leaf has the same semantics as ifOperStatus.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/last-change:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_last_change'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_last_change
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceLastChange
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_last_change
+
+        The time the interface entered its current operational
+
+        state.  If the current state was entered prior to the
+
+        last re-initialization of the local network management
+
+        subsystem, then this node is not present.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_last_change
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceLastChange
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_last_change
+
+        The time the interface entered its current operational
+
+        state.  If the current state was entered prior to the
+
+        last re-initialization of the local network management
+
+        subsystem, then this node is not present.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/if-index:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_if_index'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_if_index
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceIfIndex
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_if_index
+
+        The ifIndex value for the ifEntry represented by this
+
+        interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_if_index
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceIfIndex
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_if_index
+
+        The ifIndex value for the ifEntry represented by this
+
+        interface.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/phys-address:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_phys_address'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_phys_address
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfacePhysAddress
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_phys_address
+
+        The interface''s address at its protocol sub-layer.  For
+
+        example, for an 802.x interface, this object normally
+
+        contains a Media Access Control (MAC) address.  The
+
+        interface''s media-specific modules must define the bit
+
+        and byte ordering and the format of the value of this
+
+        object.  For interfaces that do not have such an address
+
+        (e.g., a serial line), this node is not present.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_phys_address
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfacePhysAddress
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_phys_address
+
+        The interface''s address at its protocol sub-layer.  For
+
+        example, for an 802.x interface, this object normally
+
+        contains a Media Access Control (MAC) address.  The
+
+        interface''s media-specific modules must define the bit
+
+        and byte ordering and the format of the value of this
+
+        object.  For interfaces that do not have such an address
+
+        (e.g., a serial line), this node is not present.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/higher-layer-if:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_higher_layer_if'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_higher_layer_if
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceHigherLayerIf
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_higher_layer_if
+
+        A list of references to interfaces layered on top of this
+
+        interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_higher_layer_if
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceHigherLayerIf
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_higher_layer_if
+
+        A list of references to interfaces layered on top of this
+
+        interface.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/lower-layer-if:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_lower_layer_if'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_lower_layer_if
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceLowerLayerIf
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_lower_layer_if
+
+        A list of references to interfaces layered underneath this
+
+        interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_lower_layer_if
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceLowerLayerIf
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_lower_layer_if
+
+        A list of references to interfaces layered underneath this
+
+        interface.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/speed:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_speed'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_speed
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceSpeed
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_speed
+
+        An estimate of the interface''s current bandwidth in bits
+
+        per second.  For interfaces that do not vary in
+
+        bandwidth or for those where no accurate estimation can
+
+        be made, this node should contain the nominal bandwidth.
+
+        For interfaces that have no concept of bandwidth, this
+
+        node is not present.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_speed
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceSpeed
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_speed
+
+        An estimate of the interface''s current bandwidth in bits
+
+        per second.  For interfaces that do not vary in
+
+        bandwidth or for those where no accurate estimation can
+
+        be made, this node should contain the nominal bandwidth.
+
+        For interfaces that have no concept of bandwidth, this
+
+        node is not present.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatistics
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics
+
+        A collection of interface-related statistics objects.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatistics
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics
+
+        A collection of interface-related statistics objects.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/discontinuity-time:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_discontinuity_time'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_discontinuity_time
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsDiscontinuityTime
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_discontinuity_time
+
+        The time on the most recent occasion at which any one or
+
+        more of this interface''s counters suffered a
+
+        discontinuity.  If no such discontinuities have occurred
+
+        since the last re-initialization of the local management
+
+        subsystem, then this node contains the time the local
+
+        management subsystem re-initialized itself.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_discontinuity_time
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsDiscontinuityTime
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_discontinuity_time
+
+        The time on the most recent occasion at which any one or
+
+        more of this interface''s counters suffered a
+
+        discontinuity.  If no such discontinuities have occurred
+
+        since the last re-initialization of the local management
+
+        subsystem, then this node contains the time the local
+
+        management subsystem re-initialized itself.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-octets:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_octets'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_octets
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInOctets
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_octets
+
+        The total number of octets received on the interface,
+
+        including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_octets
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInOctets
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_octets
+
+        The total number of octets received on the interface,
+
+        including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-unicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_unicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_unicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInUnicastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_unicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were not addressed to a
+
+        multicast or broadcast address at this sub-layer.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_unicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInUnicastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_unicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were not addressed to a
+
+        multicast or broadcast address at this sub-layer.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-broadcast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_broadcast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_broadcast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInBroadcastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_broadcast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a broadcast
+
+        address at this sub-layer.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_broadcast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInBroadcastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_broadcast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a broadcast
+
+        address at this sub-layer.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-multicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_multicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_multicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInMulticastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_multicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a multicast
+
+        address at this sub-layer.  For a MAC-layer protocol,
+
+        this includes both Group and Functional addresses.
+
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_multicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInMulticastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_multicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a multicast
+
+        address at this sub-layer.  For a MAC-layer protocol,
+
+        this includes both Group and Functional addresses.
+
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-discards:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_discards'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_discards
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInDiscards
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_discards
+
+        The number of inbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being deliverable to a higher-layer
+
+        protocol.  One possible reason for discarding such a
+
+        packet could be to free up buffer space.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_discards
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInDiscards
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_discards
+
+        The number of inbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being deliverable to a higher-layer
+
+        protocol.  One possible reason for discarding such a
+
+        packet could be to free up buffer space.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-errors:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_errors'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_errors
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInErrors
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_errors
+
+        For packet-oriented interfaces, the number of inbound
+
+        packets that contained errors preventing them from being
+
+        deliverable to a higher-layer protocol.  For character-
+
+        oriented or fixed-length interfaces, the number of
+
+        inbound transmission units that contained errors
+
+        preventing them from being deliverable to a higher-layer
+
+        protocol.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_errors
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInErrors
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_errors
+
+        For packet-oriented interfaces, the number of inbound
+
+        packets that contained errors preventing them from being
+
+        deliverable to a higher-layer protocol.  For character-
+
+        oriented or fixed-length interfaces, the number of
+
+        inbound transmission units that contained errors
+
+        preventing them from being deliverable to a higher-layer
+
+        protocol.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/in-unknown-protos:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_in_unknown_protos'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_in_unknown_protos
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsInUnknownProtos
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_in_unknown_protos
+
+        For packet-oriented interfaces, the number of packets
+
+        received via the interface that were discarded because
+
+        of an unknown or unsupported protocol.  For
+
+        character-oriented or fixed-length interfaces that
+
+        support protocol multiplexing, the number of
+
+        transmission units received via the interface that were
+
+        discarded because of an unknown or unsupported protocol.
+
+        For any interface that does not support protocol
+
+        multiplexing, this counter is not present.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_in_unknown_protos
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsInUnknownProtos
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_in_unknown_protos
+
+        For packet-oriented interfaces, the number of packets
+
+        received via the interface that were discarded because
+
+        of an unknown or unsupported protocol.  For
+
+        character-oriented or fixed-length interfaces that
+
+        support protocol multiplexing, the number of
+
+        transmission units received via the interface that were
+
+        discarded because of an unknown or unsupported protocol.
+
+        For any interface that does not support protocol
+
+        multiplexing, this counter is not present.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/out-octets:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_out_octets'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_out_octets
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsOutOctets
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_out_octets
+
+        The total number of octets transmitted out of the
+
+        interface, including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_out_octets
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsOutOctets
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_out_octets
+
+        The total number of octets transmitted out of the
+
+        interface, including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/out-unicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_out_unicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_out_unicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsOutUnicastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_out_unicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were not addressed
+
+        to a multicast or broadcast address at this sub-layer,
+
+        including those that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_out_unicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsOutUnicastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_out_unicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were not addressed
+
+        to a multicast or broadcast address at this sub-layer,
+
+        including those that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/out-broadcast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_out_broadcast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_out_broadcast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsOutBroadcastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_out_broadcast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        broadcast address at this sub-layer, including those
+
+        that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_out_broadcast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsOutBroadcastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_out_broadcast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        broadcast address at this sub-layer, including those
+
+        that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/out-multicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_out_multicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_out_multicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsOutMulticastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_out_multicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        multicast address at this sub-layer, including those
+
+        that were discarded or not sent.  For a MAC-layer
+
+        protocol, this includes both Group and Functional
+
+        addresses.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_out_multicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsOutMulticastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_out_multicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        multicast address at this sub-layer, including those
+
+        that were discarded or not sent.  For a MAC-layer
+
+        protocol, this includes both Group and Functional
+
+        addresses.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/out-discards:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_out_discards'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_out_discards
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsOutDiscards
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_out_discards
+
+        The number of outbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being transmitted.  One possible reason
+
+        for discarding such a packet could be to free up buffer
+
+        space.
+
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_out_discards
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsOutDiscards
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_out_discards
+
+        The number of outbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being transmitted.  One possible reason
+
+        for discarding such a packet could be to free up buffer
+
+        space.
+
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces/interface={name}/statistics/out-errors:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_interface_statistics_out_errors'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_interface_statistics_out_errors
+      x-operationIdCamelCase: GetTestDataNodesInterfacesInterfaceStatisticsOutErrors
+      description: 'OperationId: get_test_data_nodes_interfaces_interface_statistics_out_errors
+
+        For packet-oriented interfaces, the number of outbound
+
+        packets that could not be transmitted because of errors.
+
+        For character-oriented or fixed-length interfaces, the
+
+        number of outbound transmission units that could not be
+
+        transmitted because of errors.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A device MAY restrict the allowed values for this leaf,
+
+          possibly depending on the type of the interface.
+
+          For system-controlled interfaces, this leaf is the
+
+          device-specific name of the interface.
+
+
+          If a client tries to create configuration for a
+
+          system-controlled interface that is not present in the
+
+          operational state, the server MAY reject the request if
+
+          the implementation does not support pre-provisioning of
+
+          interfaces or if the name refers to an interface that can
+
+          never exist in the system.  A Network Configuration
+
+          Protocol (NETCONF) server MUST reply with an rpc-error
+
+          with the error-tag ''invalid-value'' in this case.
+
+
+          If the device supports pre-provisioning of interface
+
+          configuration, the ''pre-provisioning'' feature is
+
+          advertised.
+
+
+          If the device allows arbitrarily named user-controlled
+
+          interfaces, the ''arbitrary-names'' feature is advertised.
+
+          When a configured user-controlled interface is created by
+
+          the system, it is instantiated with the same name in the
+
+          operational state.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_interface_statistics_out_errors
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesInterfaceStatisticsOutErrors
+      description: 'OperationId: head_test_data_nodes_interfaces_interface_statistics_out_errors
+
+        For packet-oriented interfaces, the number of outbound
+
+        packets that could not be transmitted because of errors.
+
+        For character-oriented or fixed-length interfaces, the
+
+        number of outbound transmission units that could not be
+
+        transmitted because of errors.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state:
+    get:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state
+      x-operationIdCamelCase: GetTestDataNodesInterfacesState
+      description: 'OperationId: get_test_data_nodes_interfaces_state
+
+        Data nodes for the operational state of interfaces.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesState
+      description: 'OperationId: head_test_data_nodes_interfaces_state
+
+        Data nodes for the operational state of interfaces.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterface
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface
+
+        The list of interfaces on the device.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list, whether or not they are
+
+        configured.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterface
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface
+
+        The list of interfaces on the device.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list, whether or not they are
+
+        configured.'
+  /restconf/data/test-data-nodes:interfaces-state/interface:
+    get:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_list_test_data_nodes_interfaces_state_interface
+      x-operationIdCamelCase: GetListTestDataNodesInterfacesStateInterface
+      description: 'OperationId: get_list_test_data_nodes_interfaces_state_interface
+
+        The list of interfaces on the device.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list, whether or not they are
+
+        configured.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters: []
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_list_test_data_nodes_interfaces_state_interface
+      x-operationIdCamelCase: HeadListTestDataNodesInterfacesStateInterface
+      description: 'OperationId: head_list_test_data_nodes_interfaces_state_interface
+
+        The list of interfaces on the device.
+
+
+        System-controlled interfaces created by the system are
+
+        always present in this list, whether or not they are
+
+        configured.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/type:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_type'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_type
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceType
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_type
+
+        The type of the interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_type
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceType
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_type
+
+        The type of the interface.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/admin-status:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_admin_status'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_admin_status
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceAdminStatus
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_admin_status
+
+        The desired state of the interface.
+
+
+        This leaf has the same read semantics as ifAdminStatus.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_admin_status
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceAdminStatus
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_admin_status
+
+        The desired state of the interface.
+
+
+        This leaf has the same read semantics as ifAdminStatus.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/oper-status:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_oper_status'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_oper_status
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceOperStatus
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_oper_status
+
+        The current operational state of the interface.
+
+
+        This leaf has the same semantics as ifOperStatus.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_oper_status
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceOperStatus
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_oper_status
+
+        The current operational state of the interface.
+
+
+        This leaf has the same semantics as ifOperStatus.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/last-change:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_last_change'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_last_change
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceLastChange
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_last_change
+
+        The time the interface entered its current operational
+
+        state.  If the current state was entered prior to the
+
+        last re-initialization of the local network management
+
+        subsystem, then this node is not present.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_last_change
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceLastChange
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_last_change
+
+        The time the interface entered its current operational
+
+        state.  If the current state was entered prior to the
+
+        last re-initialization of the local network management
+
+        subsystem, then this node is not present.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/if-index:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_if_index'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_if_index
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceIfIndex
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_if_index
+
+        The ifIndex value for the ifEntry represented by this
+
+        interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_if_index
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceIfIndex
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_if_index
+
+        The ifIndex value for the ifEntry represented by this
+
+        interface.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/phys-address:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_phys_address'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_phys_address
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfacePhysAddress
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_phys_address
+
+        The interface''s address at its protocol sub-layer.  For
+
+        example, for an 802.x interface, this object normally
+
+        contains a Media Access Control (MAC) address.  The
+
+        interface''s media-specific modules must define the bit
+
+        and byte ordering and the format of the value of this
+
+        object.  For interfaces that do not have such an address
+
+        (e.g., a serial line), this node is not present.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_phys_address
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfacePhysAddress
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_phys_address
+
+        The interface''s address at its protocol sub-layer.  For
+
+        example, for an 802.x interface, this object normally
+
+        contains a Media Access Control (MAC) address.  The
+
+        interface''s media-specific modules must define the bit
+
+        and byte ordering and the format of the value of this
+
+        object.  For interfaces that do not have such an address
+
+        (e.g., a serial line), this node is not present.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/higher-layer-if:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_higher_layer_if'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_higher_layer_if
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceHigherLayerIf
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_higher_layer_if
+
+        A list of references to interfaces layered on top of this
+
+        interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_higher_layer_if
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceHigherLayerIf
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_higher_layer_if
+
+        A list of references to interfaces layered on top of this
+
+        interface.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/lower-layer-if:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_lower_layer_if'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_lower_layer_if
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceLowerLayerIf
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_lower_layer_if
+
+        A list of references to interfaces layered underneath this
+
+        interface.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_lower_layer_if
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceLowerLayerIf
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_lower_layer_if
+
+        A list of references to interfaces layered underneath this
+
+        interface.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/speed:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_speed'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_speed
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceSpeed
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_speed
+
+        An estimate of the interface''s current bandwidth in bits
+
+        per second.  For interfaces that do not vary in
+
+        bandwidth or for those where no accurate estimation can
+
+
+        be made, this node should contain the nominal bandwidth.
+
+        For interfaces that have no concept of bandwidth, this
+
+        node is not present.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_speed
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceSpeed
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_speed
+
+        An estimate of the interface''s current bandwidth in bits
+
+        per second.  For interfaces that do not vary in
+
+        bandwidth or for those where no accurate estimation can
+
+
+        be made, this node should contain the nominal bandwidth.
+
+        For interfaces that have no concept of bandwidth, this
+
+        node is not present.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatistics
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics
+
+        A collection of interface-related statistics objects.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatistics
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics
+
+        A collection of interface-related statistics objects.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/discontinuity-time:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_discontinuity_time'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_discontinuity_time
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsDiscontinuityTime
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_discontinuity_time
+
+        The time on the most recent occasion at which any one or
+
+        more of this interface''s counters suffered a
+
+        discontinuity.  If no such discontinuities have occurred
+
+        since the last re-initialization of the local management
+
+        subsystem, then this node contains the time the local
+
+        management subsystem re-initialized itself.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_discontinuity_time
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsDiscontinuityTime
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_discontinuity_time
+
+        The time on the most recent occasion at which any one or
+
+        more of this interface''s counters suffered a
+
+        discontinuity.  If no such discontinuities have occurred
+
+        since the last re-initialization of the local management
+
+        subsystem, then this node contains the time the local
+
+        management subsystem re-initialized itself.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-octets:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_octets'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_octets
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInOctets
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_octets
+
+        The total number of octets received on the interface,
+
+        including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_octets
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInOctets
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_octets
+
+        The total number of octets received on the interface,
+
+        including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-unicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_unicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_unicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInUnicastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_unicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were not addressed to a
+
+        multicast or broadcast address at this sub-layer.
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_unicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInUnicastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_unicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were not addressed to a
+
+        multicast or broadcast address at this sub-layer.
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-broadcast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_broadcast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_broadcast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInBroadcastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_broadcast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a broadcast
+
+        address at this sub-layer.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_broadcast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInBroadcastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_broadcast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a broadcast
+
+        address at this sub-layer.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-multicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_multicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_multicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInMulticastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_multicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a multicast
+
+        address at this sub-layer.  For a MAC-layer protocol,
+
+        this includes both Group and Functional addresses.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_multicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInMulticastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_multicast_pkts
+
+        The number of packets, delivered by this sub-layer to a
+
+        higher (sub-)layer, that were addressed to a multicast
+
+        address at this sub-layer.  For a MAC-layer protocol,
+
+        this includes both Group and Functional addresses.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-discards:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_discards'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_discards
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInDiscards
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_discards
+
+        The number of inbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being deliverable to a higher-layer
+
+        protocol.  One possible reason for discarding such a
+
+        packet could be to free up buffer space.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_discards
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInDiscards
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_discards
+
+        The number of inbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being deliverable to a higher-layer
+
+        protocol.  One possible reason for discarding such a
+
+        packet could be to free up buffer space.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-errors:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_errors'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_errors
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInErrors
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_errors
+
+        For packet-oriented interfaces, the number of inbound
+
+        packets that contained errors preventing them from being
+
+        deliverable to a higher-layer protocol.  For character-
+
+        oriented or fixed-length interfaces, the number of
+
+        inbound transmission units that contained errors
+
+        preventing them from being deliverable to a higher-layer
+
+        protocol.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_errors
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInErrors
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_errors
+
+        For packet-oriented interfaces, the number of inbound
+
+        packets that contained errors preventing them from being
+
+        deliverable to a higher-layer protocol.  For character-
+
+        oriented or fixed-length interfaces, the number of
+
+        inbound transmission units that contained errors
+
+        preventing them from being deliverable to a higher-layer
+
+        protocol.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/in-unknown-protos:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_in_unknown_protos'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_in_unknown_protos
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsInUnknownProtos
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_in_unknown_protos
+
+        For packet-oriented interfaces, the number of packets
+
+        received via the interface that were discarded because
+
+        of an unknown or unsupported protocol.  For
+
+        character-oriented or fixed-length interfaces that
+
+        support protocol multiplexing, the number of
+
+        transmission units received via the interface that were
+
+        discarded because of an unknown or unsupported protocol.
+
+        For any interface that does not support protocol
+
+        multiplexing, this counter is not present.
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_in_unknown_protos
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsInUnknownProtos
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_in_unknown_protos
+
+        For packet-oriented interfaces, the number of packets
+
+        received via the interface that were discarded because
+
+        of an unknown or unsupported protocol.  For
+
+        character-oriented or fixed-length interfaces that
+
+        support protocol multiplexing, the number of
+
+        transmission units received via the interface that were
+
+        discarded because of an unknown or unsupported protocol.
+
+        For any interface that does not support protocol
+
+        multiplexing, this counter is not present.
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/out-octets:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_out_octets'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_out_octets
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsOutOctets
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_out_octets
+
+        The total number of octets transmitted out of the
+
+        interface, including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_out_octets
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsOutOctets
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_out_octets
+
+        The total number of octets transmitted out of the
+
+        interface, including framing characters.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/out-unicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_out_unicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_out_unicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsOutUnicastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_out_unicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were not addressed
+
+        to a multicast or broadcast address at this sub-layer,
+
+        including those that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_out_unicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsOutUnicastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_out_unicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were not addressed
+
+        to a multicast or broadcast address at this sub-layer,
+
+        including those that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/out-broadcast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_out_broadcast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_out_broadcast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsOutBroadcastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_out_broadcast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        broadcast address at this sub-layer, including those
+
+        that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_out_broadcast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsOutBroadcastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_out_broadcast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        broadcast address at this sub-layer, including those
+
+        that were discarded or not sent.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/out-multicast-pkts:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_out_multicast_pkts'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_out_multicast_pkts
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsOutMulticastPkts
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_out_multicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        multicast address at this sub-layer, including those
+
+        that were discarded or not sent.  For a MAC-layer
+
+        protocol, this includes both Group and Functional
+
+        addresses.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_out_multicast_pkts
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsOutMulticastPkts
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_out_multicast_pkts
+
+        The total number of packets that higher-level protocols
+
+        requested be transmitted and that were addressed to a
+
+        multicast address at this sub-layer, including those
+
+        that were discarded or not sent.  For a MAC-layer
+
+        protocol, this includes both Group and Functional
+
+        addresses.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/out-discards:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_out_discards'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_out_discards
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsOutDiscards
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_out_discards
+
+        The number of outbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being transmitted.  One possible reason
+
+        for discarding such a packet could be to free up buffer
+
+        space.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_out_discards
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsOutDiscards
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_out_discards
+
+        The number of outbound packets that were chosen to be
+
+        discarded even though no errors had been detected to
+
+        prevent their being transmitted.  One possible reason
+
+        for discarding such a packet could be to free up buffer
+
+        space.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+  /restconf/data/test-data-nodes:interfaces-state/interface={name}/statistics/out-errors:
+    get:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/get_test_data_nodes_interfaces_state_interface_statistics_out_errors'
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: get_test_data_nodes_interfaces_state_interface_statistics_out_errors
+      x-operationIdCamelCase: GetTestDataNodesInterfacesStateInterfaceStatisticsOutErrors
+      description: 'OperationId: get_test_data_nodes_interfaces_state_interface_statistics_out_errors
+
+        For packet-oriented interfaces, the number of outbound
+
+        packets that could not be transmitted because of errors.
+
+        For character-oriented or fixed-length interfaces, the
+
+        number of outbound transmission units that could not be
+
+        transmitted because of errors.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+    head:
+      tags:
+      - test-data-nodes
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+        description: 'The name of the interface.
+
+
+          A server implementation MAY map this leaf to the ifName
+
+          MIB object.  Such an implementation needs to use some
+
+          mechanism to handle the differences in size and characters
+
+          allowed between this leaf and ifName.  The definition of
+
+          such a mechanism is outside the scope of this document.'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+      x-config: 'false'
+      operationId: head_test_data_nodes_interfaces_state_interface_statistics_out_errors
+      x-operationIdCamelCase: HeadTestDataNodesInterfacesStateInterfaceStatisticsOutErrors
+      description: 'OperationId: head_test_data_nodes_interfaces_state_interface_statistics_out_errors
+
+        For packet-oriented interfaces, the number of outbound
+
+        packets that could not be transmitted because of errors.
+
+        For character-oriented or fixed-length interfaces, the
+
+        number of outbound transmission units that could not be
+
+        transmitted because of errors.
+
+
+        Discontinuities in the value of this counter can occur
+
+        at re-initialization of the management system and at
+
+        other times as indicated by the value of
+
+        ''discontinuity-time''.'
+components:
+  securitySchemes:
+    basic:
+      scheme: basic
+      type: http
+    bearer:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http
+  schemas:
+    test_data_nodes_interfaces:
+      type: object
+      properties:
+        test-data-nodes:interfaces:
+          type: object
+          properties:
+            interface:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  description:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  type:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  enabled:
+                    default: 'true'
+                    format: boolean
+                    type: boolean
+                    x-yang-type: boolean
+                  link-up-down-trap-enable:
+                    enum:
+                    - enabled
+                    - disabled
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+    post_test_data_nodes_interfaces:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces'
+    put_test_data_nodes_interfaces:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces'
+    patch_test_data_nodes_interfaces:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces'
+    get_test_data_nodes_interfaces:
+      type: object
+      properties:
+        test-data-nodes:interfaces:
+          type: object
+          properties:
+            interface:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  description:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  type:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  enabled:
+                    default: 'true'
+                    format: boolean
+                    type: boolean
+                    x-yang-type: boolean
+                  link-up-down-trap-enable:
+                    enum:
+                    - enabled
+                    - disabled
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  admin-status:
+                    enum:
+                    - up
+                    - down
+                    - testing
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  oper-status:
+                    enum:
+                    - up
+                    - down
+                    - testing
+                    - unknown
+                    - dormant
+                    - not-present
+                    - lower-layer-down
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  last-change:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                    x-yang-type: string
+                  if-index:
+                    format: int32
+                    maximum: 2147483647
+                    minimum: 1
+                    type: integer
+                    x-range: 1..2147483647
+                    x-yang-type: int32
+                  phys-address:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  higher-layer-if:
+                    type: array
+                    items:
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                  lower-layer-if:
+                    type: array
+                    items:
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                  speed:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  statistics:
+                    type: object
+                    properties:
+                      discontinuity-time:
+                        maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                        x-yang-type: string
+                      in-octets:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-unicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-broadcast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-multicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-discards:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      in-errors:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      in-unknown-protos:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      out-octets:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-unicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-broadcast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-multicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-discards:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      out-errors:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+    test_data_nodes_interfaces_interface:
+      type: object
+      properties:
+        test-data-nodes:interface:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            properties:
+              name:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              description:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              type:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              enabled:
+                default: 'true'
+                format: boolean
+                type: boolean
+                x-yang-type: boolean
+              link-up-down-trap-enable:
+                enum:
+                - enabled
+                - disabled
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+    put_test_data_nodes_interfaces_interface:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface'
+    patch_test_data_nodes_interfaces_interface:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface'
+    get_test_data_nodes_interfaces_interface:
+      type: object
+      properties:
+        test-data-nodes:interface:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            properties:
+              name:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              description:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              type:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              enabled:
+                default: 'true'
+                format: boolean
+                type: boolean
+                x-yang-type: boolean
+              link-up-down-trap-enable:
+                enum:
+                - enabled
+                - disabled
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              admin-status:
+                enum:
+                - up
+                - down
+                - testing
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              oper-status:
+                enum:
+                - up
+                - down
+                - testing
+                - unknown
+                - dormant
+                - not-present
+                - lower-layer-down
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              last-change:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                x-yang-type: string
+              if-index:
+                format: int32
+                maximum: 2147483647
+                minimum: 1
+                type: integer
+                x-range: 1..2147483647
+                x-yang-type: int32
+              phys-address:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              higher-layer-if:
+                type: array
+                items:
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+              lower-layer-if:
+                type: array
+                items:
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+              speed:
+                format: int64
+                maximum: 18446744073709551615
+                minimum: 0
+                type: integer
+                x-yang-type: uint64
+              statistics:
+                type: object
+                properties:
+                  discontinuity-time:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                    x-yang-type: string
+                  in-octets:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-unicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-broadcast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-multicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-discards:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  in-errors:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  in-unknown-protos:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  out-octets:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-unicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-broadcast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-multicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-discards:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  out-errors:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+    post_list_test_data_nodes_interfaces_interface:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface'
+    put_list_test_data_nodes_interfaces_interface:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface'
+    patch_list_test_data_nodes_interfaces_interface:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface'
+    test_data_nodes_interfaces_interface_description:
+      type: object
+      properties:
+        test-data-nodes:description:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    post_test_data_nodes_interfaces_interface_description:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_description'
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_type'
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_enabled'
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_link_up_down_trap_enable'
+    put_test_data_nodes_interfaces_interface_description:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_description'
+    patch_test_data_nodes_interfaces_interface_description:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_description'
+    get_test_data_nodes_interfaces_interface_description:
+      type: object
+      properties:
+        test-data-nodes:description:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    test_data_nodes_interfaces_interface_type:
+      type: object
+      properties:
+        test-data-nodes:type:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    put_test_data_nodes_interfaces_interface_type:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_type'
+    patch_test_data_nodes_interfaces_interface_type:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_type'
+    get_test_data_nodes_interfaces_interface_type:
+      type: object
+      properties:
+        test-data-nodes:type:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    test_data_nodes_interfaces_interface_enabled:
+      type: object
+      properties:
+        test-data-nodes:enabled:
+          default: 'true'
+          format: boolean
+          type: boolean
+          x-yang-type: boolean
+    put_test_data_nodes_interfaces_interface_enabled:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_enabled'
+    patch_test_data_nodes_interfaces_interface_enabled:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_enabled'
+    get_test_data_nodes_interfaces_interface_enabled:
+      type: object
+      properties:
+        test-data-nodes:enabled:
+          default: 'true'
+          format: boolean
+          type: boolean
+          x-yang-type: boolean
+    test_data_nodes_interfaces_interface_link_up_down_trap_enable:
+      type: object
+      properties:
+        test-data-nodes:link-up-down-trap-enable:
+          enum:
+          - enabled
+          - disabled
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    put_test_data_nodes_interfaces_interface_link_up_down_trap_enable:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_link_up_down_trap_enable'
+    patch_test_data_nodes_interfaces_interface_link_up_down_trap_enable:
+      allOf:
+      - $ref: '#/components/schemas/test_data_nodes_interfaces_interface_link_up_down_trap_enable'
+    get_test_data_nodes_interfaces_interface_link_up_down_trap_enable:
+      type: object
+      properties:
+        test-data-nodes:link-up-down-trap-enable:
+          enum:
+          - enabled
+          - disabled
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    get_test_data_nodes_interfaces_interface_admin_status:
+      type: object
+      properties:
+        test-data-nodes:admin-status:
+          enum:
+          - up
+          - down
+          - testing
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    get_test_data_nodes_interfaces_interface_oper_status:
+      type: object
+      properties:
+        test-data-nodes:oper-status:
+          enum:
+          - up
+          - down
+          - testing
+          - unknown
+          - dormant
+          - not-present
+          - lower-layer-down
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    get_test_data_nodes_interfaces_interface_last_change:
+      type: object
+      properties:
+        test-data-nodes:last-change:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+          x-yang-type: string
+    get_test_data_nodes_interfaces_interface_if_index:
+      type: object
+      properties:
+        test-data-nodes:if-index:
+          format: int32
+          maximum: 2147483647
+          minimum: 1
+          type: integer
+          x-range: 1..2147483647
+          x-yang-type: int32
+    get_test_data_nodes_interfaces_interface_phys_address:
+      type: object
+      properties:
+        test-data-nodes:phys-address:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    get_test_data_nodes_interfaces_interface_higher_layer_if:
+      type: object
+      properties:
+        test-data-nodes:higher-layer-if:
+          type: array
+          items:
+            maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-yang-type: string
+    get_test_data_nodes_interfaces_interface_lower_layer_if:
+      type: object
+      properties:
+        test-data-nodes:lower-layer-if:
+          type: array
+          items:
+            maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-yang-type: string
+    get_test_data_nodes_interfaces_interface_speed:
+      type: object
+      properties:
+        test-data-nodes:speed:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics:
+      type: object
+      properties:
+        test-data-nodes:statistics:
+          type: object
+          properties:
+            discontinuity-time:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+              x-yang-type: string
+            in-octets:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-unicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-broadcast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-multicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-discards:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            in-errors:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            in-unknown-protos:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            out-octets:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-unicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-broadcast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-multicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-discards:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            out-errors:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+    get_test_data_nodes_interfaces_interface_statistics_discontinuity_time:
+      type: object
+      properties:
+        test-data-nodes:discontinuity-time:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+          x-yang-type: string
+    get_test_data_nodes_interfaces_interface_statistics_in_octets:
+      type: object
+      properties:
+        test-data-nodes:in-octets:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_in_unicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:in-unicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_in_broadcast_pkts:
+      type: object
+      properties:
+        test-data-nodes:in-broadcast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_in_multicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:in-multicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_in_discards:
+      type: object
+      properties:
+        test-data-nodes:in-discards:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_interface_statistics_in_errors:
+      type: object
+      properties:
+        test-data-nodes:in-errors:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_interface_statistics_in_unknown_protos:
+      type: object
+      properties:
+        test-data-nodes:in-unknown-protos:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_interface_statistics_out_octets:
+      type: object
+      properties:
+        test-data-nodes:out-octets:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_out_unicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:out-unicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_out_broadcast_pkts:
+      type: object
+      properties:
+        test-data-nodes:out-broadcast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_out_multicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:out-multicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_interface_statistics_out_discards:
+      type: object
+      properties:
+        test-data-nodes:out-discards:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_interface_statistics_out_errors:
+      type: object
+      properties:
+        test-data-nodes:out-errors:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_state:
+      type: object
+      properties:
+        test-data-nodes:interfaces-state:
+          type: object
+          properties:
+            interface:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  type:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  admin-status:
+                    enum:
+                    - up
+                    - down
+                    - testing
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  oper-status:
+                    enum:
+                    - up
+                    - down
+                    - testing
+                    - unknown
+                    - dormant
+                    - not-present
+                    - lower-layer-down
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-yang-type: string
+                  last-change:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                    x-yang-type: string
+                  if-index:
+                    format: int32
+                    maximum: 2147483647
+                    minimum: 1
+                    type: integer
+                    x-range: 1..2147483647
+                    x-yang-type: int32
+                  phys-address:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                    x-yang-type: string
+                  higher-layer-if:
+                    type: array
+                    items:
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                  lower-layer-if:
+                    type: array
+                    items:
+                      maxLength: 18446744073709551615
+                      minLength: 0
+                      type: string
+                      x-yang-type: string
+                  speed:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  statistics:
+                    type: object
+                    properties:
+                      discontinuity-time:
+                        maxLength: 18446744073709551615
+                        minLength: 0
+                        type: string
+                        x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                        x-yang-type: string
+                      in-octets:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-unicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-broadcast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-multicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      in-discards:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      in-errors:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      in-unknown-protos:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      out-octets:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-unicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-broadcast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-multicast-pkts:
+                        format: int64
+                        maximum: 18446744073709551615
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint64
+                      out-discards:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+                      out-errors:
+                        format: int32
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                        x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface:
+      type: object
+      properties:
+        test-data-nodes:interface:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              type:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              admin-status:
+                enum:
+                - up
+                - down
+                - testing
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              oper-status:
+                enum:
+                - up
+                - down
+                - testing
+                - unknown
+                - dormant
+                - not-present
+                - lower-layer-down
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-yang-type: string
+              last-change:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                x-yang-type: string
+              if-index:
+                format: int32
+                maximum: 2147483647
+                minimum: 1
+                type: integer
+                x-range: 1..2147483647
+                x-yang-type: int32
+              phys-address:
+                maxLength: 18446744073709551615
+                minLength: 0
+                type: string
+                x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+                x-yang-type: string
+              higher-layer-if:
+                type: array
+                items:
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+              lower-layer-if:
+                type: array
+                items:
+                  maxLength: 18446744073709551615
+                  minLength: 0
+                  type: string
+                  x-yang-type: string
+              speed:
+                format: int64
+                maximum: 18446744073709551615
+                minimum: 0
+                type: integer
+                x-yang-type: uint64
+              statistics:
+                type: object
+                properties:
+                  discontinuity-time:
+                    maxLength: 18446744073709551615
+                    minLength: 0
+                    type: string
+                    x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+                    x-yang-type: string
+                  in-octets:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-unicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-broadcast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-multicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  in-discards:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  in-errors:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  in-unknown-protos:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  out-octets:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-unicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-broadcast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-multicast-pkts:
+                    format: int64
+                    maximum: 18446744073709551615
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint64
+                  out-discards:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+                  out-errors:
+                    format: int32
+                    maximum: 4294967295
+                    minimum: 0
+                    type: integer
+                    x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface_type:
+      type: object
+      properties:
+        test-data-nodes:type:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_admin_status:
+      type: object
+      properties:
+        test-data-nodes:admin-status:
+          enum:
+          - up
+          - down
+          - testing
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_oper_status:
+      type: object
+      properties:
+        test-data-nodes:oper-status:
+          enum:
+          - up
+          - down
+          - testing
+          - unknown
+          - dormant
+          - not-present
+          - lower-layer-down
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_last_change:
+      type: object
+      properties:
+        test-data-nodes:last-change:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+          x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_if_index:
+      type: object
+      properties:
+        test-data-nodes:if-index:
+          format: int32
+          maximum: 2147483647
+          minimum: 1
+          type: integer
+          x-range: 1..2147483647
+          x-yang-type: int32
+    get_test_data_nodes_interfaces_state_interface_phys_address:
+      type: object
+      properties:
+        test-data-nodes:phys-address:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?
+          x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_higher_layer_if:
+      type: object
+      properties:
+        test-data-nodes:higher-layer-if:
+          type: array
+          items:
+            maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_lower_layer_if:
+      type: object
+      properties:
+        test-data-nodes:lower-layer-if:
+          type: array
+          items:
+            maxLength: 18446744073709551615
+            minLength: 0
+            type: string
+            x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_speed:
+      type: object
+      properties:
+        test-data-nodes:speed:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics:
+      type: object
+      properties:
+        test-data-nodes:statistics:
+          type: object
+          properties:
+            discontinuity-time:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+              x-yang-type: string
+            in-octets:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-unicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-broadcast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-multicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            in-discards:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            in-errors:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            in-unknown-protos:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            out-octets:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-unicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-broadcast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-multicast-pkts:
+              format: int64
+              maximum: 18446744073709551615
+              minimum: 0
+              type: integer
+              x-yang-type: uint64
+            out-discards:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            out-errors:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface_statistics_discontinuity_time:
+      type: object
+      properties:
+        test-data-nodes:discontinuity-time:
+          maxLength: 18446744073709551615
+          minLength: 0
+          type: string
+          x-pattern: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})
+          x-yang-type: string
+    get_test_data_nodes_interfaces_state_interface_statistics_in_octets:
+      type: object
+      properties:
+        test-data-nodes:in-octets:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_in_unicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:in-unicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_in_broadcast_pkts:
+      type: object
+      properties:
+        test-data-nodes:in-broadcast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_in_multicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:in-multicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_in_discards:
+      type: object
+      properties:
+        test-data-nodes:in-discards:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface_statistics_in_errors:
+      type: object
+      properties:
+        test-data-nodes:in-errors:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface_statistics_in_unknown_protos:
+      type: object
+      properties:
+        test-data-nodes:in-unknown-protos:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface_statistics_out_octets:
+      type: object
+      properties:
+        test-data-nodes:out-octets:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_out_unicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:out-unicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_out_broadcast_pkts:
+      type: object
+      properties:
+        test-data-nodes:out-broadcast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_out_multicast_pkts:
+      type: object
+      properties:
+        test-data-nodes:out-multicast-pkts:
+          format: int64
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
+          x-yang-type: uint64
+    get_test_data_nodes_interfaces_state_interface_statistics_out_discards:
+      type: object
+      properties:
+        test-data-nodes:out-discards:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32
+    get_test_data_nodes_interfaces_state_interface_statistics_out_errors:
+      type: object
+      properties:
+        test-data-nodes:out-errors:
+          format: int32
+          maximum: 4294967295
+          minimum: 0
+          type: integer
+          x-yang-type: uint32

--- a/tools/openapi_tests/test-rpc.yang
+++ b/tools/openapi_tests/test-rpc.yang
@@ -1,0 +1,74 @@
+module test-rpc {
+    namespace "https://example.com/ns/example-ops";
+    prefix "ops";
+
+    organization "Example, Inc.";
+    contact "support at example.com";
+    description "Example Operations Data Model Module.";
+    revision "2016-07-07" {
+      description "Initial version.";
+      reference "example.com document 3-3373.";
+    }
+    
+    rpc reboot {
+      description "Reboot operation.";
+      input {
+        leaf delay {
+          type uint32;
+          units "seconds";
+          default 0;
+          description
+            "Number of seconds to wait before initiating the
+             reboot operation.";
+        }
+        leaf message {
+          type string;
+          description
+            "Log message to display when reboot is started.";
+        }
+        leaf language {
+          type string;
+          description "Language identifier string.";
+          reference "RFC 5646.";
+        }
+      }
+    }  
+
+    rpc get-reboot-info {
+       description
+         "Retrieve parameters used in the last reboot operation.";
+       output {
+         leaf reboot-time {
+           type uint32;
+           description
+             "The 'delay' parameter used in the last reboot
+              operation.";
+         }
+         leaf message {
+           type string;
+           description
+             "The 'message' parameter used in the last reboot
+              operation.";
+         }
+         leaf language {
+           type string;
+           description
+             "The 'language' parameter used in the last reboot
+              operation.";
+         }
+       }
+     }
+
+    rpc activate-software-image {
+        input {
+            leaf image-name {
+                type string;
+            }
+        }
+        output {
+            leaf status {
+                type string;
+            }
+        }
+    }     
+}      

--- a/tools/openapi_tests/test-rpc.yang.expect
+++ b/tools/openapi_tests/test-rpc.yang.expect
@@ -1,0 +1,214 @@
+openapi: 3.0.1
+info:
+  description: Network Management Open APIs for SONiC
+  version: 1.0.0
+  title: Sonic Network Management RESTCONF APIs
+servers:
+- url: https://
+security:
+- basic: []
+- bearer: []
+tags:
+- name: test-rpc
+  description: Operations for test-rpc
+paths:
+  /restconf/operations/test-rpc:reboot:
+    post:
+      tags:
+      - test-rpc
+      operationId: rpc_test_rpc_reboot
+      x-operationIdCamelCase: RpcTestRpcReboot
+      x-rpc: true
+      description: 'OperationId: rpc_test_rpc_reboot
+
+        Reboot operation.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/rpc_input_test_rpc_reboot'
+        required: true
+      responses:
+        '204':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/rpc_output_test_rpc_reboot'
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+  /restconf/operations/test-rpc:get-reboot-info:
+    post:
+      tags:
+      - test-rpc
+      operationId: rpc_test_rpc_get_reboot_info
+      x-operationIdCamelCase: RpcTestRpcGetRebootInfo
+      x-rpc: true
+      description: 'OperationId: rpc_test_rpc_get_reboot_info
+
+        Retrieve parameters used in the last reboot operation.'
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/rpc_input_test_rpc_get_reboot_info'
+        required: true
+      responses:
+        '204':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/rpc_output_test_rpc_get_reboot_info'
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+  /restconf/operations/test-rpc:activate-software-image:
+    post:
+      tags:
+      - test-rpc
+      operationId: rpc_test_rpc_activate_software_image
+      x-operationIdCamelCase: RpcTestRpcActivateSoftwareImage
+      x-rpc: true
+      description: 'OperationId: rpc_test_rpc_activate_software_image
+
+        '
+      requestBody:
+        content:
+          application/yang-data+json:
+            schema:
+              $ref: '#/components/schemas/rpc_input_test_rpc_activate_software_image'
+        required: true
+      responses:
+        '204':
+          content:
+            application/yang-data+json:
+              schema:
+                $ref: '#/components/schemas/rpc_output_test_rpc_activate_software_image'
+          description: No Content
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '405':
+          description: Method Not Allowed
+        '415':
+          description: Unsupported Media Type
+        '500':
+          description: Internal Server Error
+components:
+  securitySchemes:
+    basic:
+      scheme: basic
+      type: http
+    bearer:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http
+  schemas:
+    rpc_input_test_rpc_reboot:
+      type: object
+      properties:
+        test-rpc:input:
+          type: object
+          properties:
+            delay:
+              default: 0
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            message:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+            language:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+    rpc_output_test_rpc_reboot:
+      type: object
+      properties:
+        test-rpc:output:
+          type: object
+          properties: {}
+    rpc_input_test_rpc_get_reboot_info:
+      type: object
+      properties:
+        test-rpc:input:
+          type: object
+          properties: {}
+    rpc_output_test_rpc_get_reboot_info:
+      type: object
+      properties:
+        test-rpc:output:
+          type: object
+          properties:
+            reboot-time:
+              format: int32
+              maximum: 4294967295
+              minimum: 0
+              type: integer
+              x-yang-type: uint32
+            message:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+            language:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+    rpc_input_test_rpc_activate_software_image:
+      type: object
+      properties:
+        test-rpc:input:
+          type: object
+          properties:
+            image-name:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string
+    rpc_output_test_rpc_activate_software_image:
+      type: object
+      properties:
+        test-rpc:output:
+          type: object
+          properties:
+            status:
+              maxLength: 18446744073709551615
+              minLength: 0
+              type: string
+              x-yang-type: string

--- a/tools/openapi_tests/test-yang-types.yang
+++ b/tools/openapi_tests/test-yang-types.yang
@@ -1,0 +1,435 @@
+module test-yang-types {
+
+  namespace "urn:test:params:xml:ns:yang:test-yang-types";
+  prefix "yang";
+
+    organization "Example, Inc.";
+    contact "support at example.com";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.";
+
+  revision 2020-04-20 {
+    description
+      "Initial version.";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/tools/pyang/pyang_plugins/openapi.py
+++ b/tools/pyang/pyang_plugins/openapi.py
@@ -19,117 +19,141 @@
 
 import optparse
 import sys
-
 from pyang import plugin
 from pyang import util
 from pyang import statements
-import pdb
+from pyang.error import err_add
+from pyang import syntax
 import yaml
 from collections import OrderedDict
 import copy
 import os
 import mmh3
 import json
+from jinja2 import Environment, FileSystemLoader
 
 # globals
-codegenTypesToYangTypesMap = {"int8":   {"type":"integer", "format": "int32"}, 
-                              "int16":  {"type":"integer", "format": "int32"}, 
-                              "int32":  {"type":"integer", "format": "int32"}, 
-                              "int64":  {"type":"integer", "format": "int64"}, 
-                              "uint8":  {"type":"integer", "format": "int32"}, 
-                              "uint16": {"type":"integer", "format": "int32"},
-                              "uint32": {"type":"integer", "format": "int32"},
-                              "uint64": {"type":"integer", "format": "int64"}, 
-                              "decimal64": {"type":"number", "format": "double"}, 
-                              "string": {"type":"string"}, 
-                              "binary": {"type":"string", "format": "binary"}, 
-                              "boolean": {"type":"boolean"}, 
-                              "bits":  {"type":"integer", "format": "int32"}, 
-                              "identityref": {"type":"string"}, 
-                              "union": {"type":"string"}, 
-                              "counter32": {"type":"integer", "format": "int64"},
-                              "counter64": {"type":"integer", "format": "int64"},
-                              "long": {"type":"integer", "format": "int64"},
-                            }
+codegenTypesToYangTypesMap = {"int8":   {"type": "integer", "format": "int32", "x-yang-type": "int8", "minimum": -128, "maximum": 127},
+                              "int16":  {"type": "integer", "format": "int32", "x-yang-type": "int16", "minimum": -32768, "maximum": 32767},
+                              "int32":  {"type": "integer", "format": "int32", "x-yang-type": "int32", "minimum": -2147483648, "maximum": 2147483647},
+                              "int64":  {"type": "integer", "format": "int64", "x-yang-type": "int64", "minimum": -9223372036854775808, "maximum": 9223372036854775807},
+                              "uint8":  {"type": "integer", "format": "int32", "x-yang-type": "uint8", "minimum": 0, "maximum": 255},
+                              "uint16": {"type": "integer", "format": "int32", "x-yang-type": "uint16", "minimum": 0, "maximum": 65535},
+                              "uint32": {"type": "integer", "format": "int32", "x-yang-type": "uint32", "minimum": 0, "maximum": 4294967295},
+                              "uint64": {"type": "integer", "format": "int64", "x-yang-type": "uint64", "minimum": 0, "maximum": 18446744073709551615},
+                              "decimal64": {"type": "number", "format": "double", "x-yang-type": "decimal64"},
+                              "string": {"type": "string", "x-yang-type": "string", "minLength": 0, "maxLength": 18446744073709551615},
+                              "binary": {"type": "string", "format": "binary", "x-yang-type": "binary"},
+                              "boolean": {"type": "boolean", "x-yang-type": "boolean"},
+                              "bits":  {"type": "integer", "format": "int32", "x-yang-type": "bits"},
+                              "identityref": {"type": "string", "x-yang-type": "string"},
+                              "union": {"type": "string", "x-yang-type": "union"},
+                              "counter32": {"type": "integer", "format": "int64", "x-yang-type": "counter32", "minimum": -2147483648, "maximum": 2147483647},
+                              "counter64": {"type": "integer", "format": "int64", "x-yang-type": "counter64", "minimum": 0, "maximum": 18446744073709551615},
+                              "long": {"type": "integer", "format": "int64", "x-yang-type": "long", "minimum": -9223372036854775808, "maximum": 9223372036854775807}
+                              }
 moduleDict = OrderedDict()
 nodeDict = OrderedDict()
 XpathToBodyTagDict = OrderedDict()
+XpathToBodyTagDict_with_config_false = OrderedDict()
 keysToLeafRefObjSet = set()
 currentTag = None
 errorList = []
 warnList = []
 verbs = ["post", "put", "patch", "get", "delete"]
-responses = { # Common to all verbs
+responses = {  # Common to all verbs
     "500": {"description": "Internal Server Error"},
     "401": {"description": "Unauthorized"},
     "405": {"description": "Method Not Allowed"},
-    "400": {"description": "Bad request"},    
-    "415": {"description": "Unsupported Media Type"},          
+    "400": {"description": "Bad request"},
+    "415": {"description": "Unsupported Media Type"},
 }
 verb_responses = {}
 verb_responses["rpc"] = {
     "204": {"description": "No Content"},
     "404": {"description": "Not Found"},
-    "403": {"description": "Forbidden"},              
+    "403": {"description": "Forbidden"},
 }
 verb_responses["post"] = {
     "201": {"description": "Created"},
     "409": {"description": "Conflict"},
     "404": {"description": "Not Found"},
-    "403": {"description": "Forbidden"},              
+    "403": {"description": "Forbidden"},
 }
 verb_responses["put"] = {
     "201": {"description": "Created"},
     "204": {"description": "No Content"},
     "404": {"description": "Not Found"},
     "409": {"description": "Conflict"},
-    "403": {"description": "Forbidden"},    
+    "403": {"description": "Forbidden"},
 }
 verb_responses["patch"] = {
     "204": {"description": "No Content"},
     "404": {"description": "Not Found"},
     "409": {"description": "Conflict"},
-    "403": {"description": "Forbidden"},         
+    "403": {"description": "Forbidden"},
 }
 verb_responses["delete"] = {
     "204": {"description": "No Content"},
     "404": {"description": "Not Found"},
 }
 verb_responses["get"] = {
-    "200": {"description": "Ok"},
+    "200": {"description": "Ok", "content": {}},
     "404": {"description": "Not Found"},
 }
+
 
 def merge_two_dicts(x, y):
     z = x.copy()   # start with x's keys and values
     z.update(y)    # modifies z with y's keys and values & returns None
     return z
 
+
 def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
     class OrderedDumper(Dumper):
         pass
+
     def _dict_representer(dumper, data):
         return dumper.represent_mapping(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             data.items())
     OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    yaml.SafeDumper.ignore_aliases = lambda *args: True
     return yaml.dump(data, stream, OrderedDumper, **kwds)
+
 
 swaggerDict = OrderedDict()
 docJson = OrderedDict()
 docJson["config"] = OrderedDict()
 docJson["operstate"] = OrderedDict()
 docJson["operations"] = OrderedDict()
-swaggerDict["swagger"] = "2.0"
+swaggerDict["openapi"] = "3.0.1"
 swaggerDict["info"] = OrderedDict()
-swaggerDict["info"]["description"] = "Network management Open APIs for Broadcom's Sonic."
+swaggerDict["servers"] = [{"url": "https://"}]
+swaggerDict["security"] = [{'basic': []}, {'bearer': []}]
+swaggerDict["info"]["description"] = "Network Management Open APIs for SONiC"
 swaggerDict["info"]["version"] = "1.0.0"
-swaggerDict["info"]["title"] =  "SONiC Network Management APIs"
-swaggerDict["schemes"] = ["https", "http"]
+swaggerDict["info"]["title"] = "Sonic Network Management RESTCONF APIs"
 swagger_tags = []
 swaggerDict["tags"] = swagger_tags
 swaggerDict["paths"] = OrderedDict()
-swaggerDict["definitions"] = OrderedDict()
+swaggerDict["components"] = OrderedDict()
+swaggerDict["components"]["securitySchemes"] = {"basic": {
+    "type": "http",
+    "scheme": "basic"
+},
+    "bearer": {
+    "type": "http",
+    "scheme": "bearer",
+    "bearerFormat": "JWT"
+}
+}
+swaggerDict["components"]["schemas"] = OrderedDict()
+schemasDict = swaggerDict["components"]["schemas"]
+globalCtx = None
+global_fd = None
+OpIdDict = OrderedDict()
+
 
 def resetDocJson():
     global docJson
@@ -138,31 +162,68 @@ def resetDocJson():
     docJson["operstate"] = OrderedDict()
     docJson["operations"] = OrderedDict()
 
+
 def resetSwaggerDict():
     global moduleDict
     global nodeDict
     global XpathToBodyTagDict
+    global XpathToBodyTagDict_with_config_false
     global keysToLeafRefObjSet
     global swaggerDict
     global swagger_tags
     global currentTag
-    
+    global schemasDict
+    global OpIdDict
+
+    OpIdDict = OrderedDict()
     moduleDict = OrderedDict()
     XpathToBodyTagDict = OrderedDict()
-    keysToLeafRefObjSet = set()    
+    XpathToBodyTagDict_with_config_false = OrderedDict()
+    keysToLeafRefObjSet = set()
 
     swaggerDict = OrderedDict()
-    swaggerDict["swagger"] = "2.0"
+    swaggerDict["openapi"] = "3.0.1"
     swaggerDict["info"] = OrderedDict()
-    swaggerDict["info"]["description"] = "Network management Open APIs for Sonic."
+    swaggerDict["servers"] = [{"url": "https://"}]
+    swaggerDict["security"] = [{'basic': []}, {'bearer': []}]
+    swaggerDict["info"]["description"] = "Network Management Open APIs for SONiC"
     swaggerDict["info"]["version"] = "1.0.0"
-    swaggerDict["info"]["title"] =  "Sonic Network Management APIs"
-    swaggerDict["schemes"] = ["https", "http"]
+    swaggerDict["info"]["title"] = "Sonic Network Management RESTCONF APIs"
     swagger_tags = []
     currentTag = None
     swaggerDict["tags"] = swagger_tags
     swaggerDict["paths"] = OrderedDict()
-    swaggerDict["definitions"] = OrderedDict()    
+    swaggerDict["components"] = OrderedDict()
+    swaggerDict["components"]["securitySchemes"] = {"basic": {
+        "type": "http",
+        "scheme": "basic"
+    },
+        "bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+    }
+    }
+    swaggerDict["components"]["schemas"] = OrderedDict()
+    schemasDict = swaggerDict["components"]["schemas"]
+
+
+def snake_to_camel(word):
+    word = word.replace('__', '_')
+    return ''.join(x.capitalize() or '_' for x in word.split('_'))
+
+
+def getOneOfTypesOred(param):
+    dtypeSet = set()
+    dtype = ""
+    for oneOfType in param:
+        if 'oneOf' in oneOfType:
+            dtypeSet.add(getOneOfTypesOred(oneOfType['oneOf']))
+            continue
+        dtypeSet.add(str(oneOfType["x-yang-type"]))
+    dtype = "|".join(dtypeSet)
+    return dtype
+
 
 def documentFormatter(doc_obj, mdFh, mode):
     if len(doc_obj) > 0:
@@ -186,8 +247,14 @@ def documentFormatter(doc_obj, mdFh, mode):
                     mdFh.write("\n| Name | Type | Description |\n")
                     mdFh.write("|:---:|:-----:|:-----:|\n")
                     for param in doc_obj[uri]["parameters"]:
-                        param["description"] = param["description"].replace('\n', ' ')
-                        mdFh.write("| %s | %s  | %s  |\n" % (param["name"], param["type"], param["description"].encode('utf8')))                
+                        param["description"] = param["description"].replace(
+                            '\n', ' ')
+                        if 'oneOf' in param["schema"]:
+                            dtype = getOneOfTypesOred(param["schema"]["oneOf"])
+                        else:
+                            dtype = param["schema"]["x-yang-type"]
+                        mdFh.write("| %s | %s  | %s  |\n" % (
+                            param["name"], dtype, param["description"].encode('utf8')))
 
                 for stmt in doc_obj[uri]:
                     if stmt == "description" or stmt == "parameters":
@@ -197,28 +264,67 @@ def documentFormatter(doc_obj, mdFh, mode):
                         reqPrefix = "Request"
                         if verb.lower() == "get":
                             reqPrefix = "Response"
-                        mdFh.write("\n<details>\n<summary>%s payload for %s</summary>\n<p>" % (reqPrefix, verb.upper()))
+                        mdFh.write(
+                            "\n<details>\n<summary>%s payload for %s</summary>\n<p>" % (reqPrefix, verb.upper()))
                         mdFh.write("\n\n```json\n")
-                        mdFh.write(json.dumps(doc_obj[uri][verb]["body"], indent=2))
+                        mdFh.write(json.dumps(
+                            doc_obj[uri][verb]["body"], indent=2))
                         mdFh.write("\n```\n")
                         mdFh.write("</p>\n</details>\n\n")
             else:
                 if 'input' in doc_obj[uri]:
-                    mdFh.write("\n<details>\n<summary>%s payload for %s</summary>\n<p>" % ("Request", "POST"))
+                    mdFh.write(
+                        "\n<details>\n<summary>%s payload for %s</summary>\n<p>" % ("Request", "POST"))
                     mdFh.write("\n\n```json\n")
                     mdFh.write(json.dumps(doc_obj[uri]["input"], indent=2))
                     mdFh.write("\n```\n")
                     mdFh.write("</p>\n</details>\n\n")
-                    
+
                 if 'output' in doc_obj[uri]:
-                    mdFh.write("\n<details>\n<summary>%s payload for %s</summary>\n<p>" % ("Response", "POST"))
+                    mdFh.write(
+                        "\n<details>\n<summary>%s payload for %s</summary>\n<p>" % ("Response", "POST"))
                     mdFh.write("\n\n```json\n")
                     mdFh.write(json.dumps(doc_obj[uri]["output"], indent=2))
                     mdFh.write("\n```\n")
-                    mdFh.write("</p>\n</details>\n\n")                
+                    mdFh.write("</p>\n</details>\n\n")
+
 
 def pyang_plugin_init():
     plugin.register_plugin(OpenApiPlugin())
+
+
+def generateServerStubs(ctx, module_name):
+    if ctx.opts.template_dir is None:
+        currentDir = os.path.dirname(os.path.realpath(__file__))
+        templateDir = os.path.join(
+            currentDir, '../../codegen/go-server/templates-yang/')
+    else:
+        templateDir = ctx.opts.template_dir
+    # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+    templateEnv = Environment(loader=FileSystemLoader(
+        templateDir), trim_blocks=True, lstrip_blocks=True)
+    # generate router.go file
+    OpIds = list(OpIdDict.keys())
+    OpIds.sort()
+    routersDotGoContent = templateEnv.get_template(
+        'routers.j2').render(OpIdDict=OpIdDict, OpIds=OpIds)
+    # generate api.go file
+    apiDotGoContent = templateEnv.get_template(
+        'controllers-api.j2').render(OpIdDict=OpIdDict, OpIds=OpIds)
+
+    if not ctx.opts.stub_outdir:
+        print("[Error]: output directory for server stubs is not specified")
+
+    module_name2 = module_name.replace('-', '_')
+    apiDotGoContent_file = os.path.join(
+        ctx.opts.stub_outdir, "api_%s.go" % (module_name2))
+    routersDotGoContent_file = os.path.join(
+        ctx.opts.stub_outdir, "routers_%s.go" % (module_name))
+    with open(routersDotGoContent_file, "w") as fp:
+        fp.write(routersDotGoContent)
+    with open(apiDotGoContent_file, "w") as fp:
+        fp.write(apiDotGoContent)
+
 
 def mdGen(ctx, module):
     if ctx.opts.with_md is None:
@@ -228,37 +334,44 @@ def mdGen(ctx, module):
         del(doc_config["/restconf/data/"])
     doc_operstate = docJson["operstate"]
     if "/restconf/data/" in doc_operstate:
-        del(doc_operstate["/restconf/data/"])        
+        del(doc_operstate["/restconf/data/"])
     doc_operations = docJson["operations"]
     if "/restconf/data/" in doc_operations:
-        del(doc_operations["/restconf/data/"]) 
+        del(doc_operations["/restconf/data/"])
 
     if len(doc_config) > 0 or len(doc_operstate) > 0 or len(doc_operations) > 0:
-        if ctx.opts.mdoutdir is None:
+        if ctx.opts.mdoutdir is None and ctx.opts.outdir:
             mdFn = ctx.opts.outdir + '/../restconf_md/' + module.i_modulename + ".md"
-        else:
+            mdFh = open(mdFn, 'w')
+        elif ctx.opts.mdoutdir:
             mdFn = ctx.opts.mdoutdir + '/' + module.i_modulename + ".md"
-        mdFh = open(mdFn,'w')
+            mdFh = open(mdFn, 'w')
+        else:
+            mdFh = global_fd
+
         mdFh.write("# The RESTCONF APIs for %s\n\n" % (module.i_modulename))
         if module.search_one('description') is not None:
-            mdFh.write("%s\n\n" % (module.search_one('description').arg.encode('utf8')))
+            mdFh.write("%s\n\n" % (module.search_one(
+                'description').arg.encode('utf8')))
     else:
         # No content
         return
 
     # Write some headers
     if len(doc_config) > 0:
-        mdFh.write("* [%s](#%s)\n" % ("Configuration APIs","Configuration-APIs"))
+        mdFh.write("* [%s](#%s)\n" %
+                   ("Configuration APIs", "Configuration-APIs"))
     if len(doc_operstate) > 0:
-        mdFh.write("* [%s](#%s)\n" % ("Operational-state APIs","Operational-state-APIs"))
+        mdFh.write("* [%s](#%s)\n" %
+                   ("Operational-state APIs", "Operational-state-APIs"))
     if len(doc_operations) > 0:
-        mdFh.write("* [%s](#%s)\n" % ("Operations API","Operations-API"))
+        mdFh.write("* [%s](#%s)\n" % ("Operations API", "Operations-API"))
 
-    documentFormatter(doc_config, mdFh, mode = "config")
-    documentFormatter(doc_operstate, mdFh, mode = "operstate")
-    documentFormatter(doc_operations, mdFh, mode = "operations")
+    documentFormatter(doc_config, mdFh, mode="config")
+    documentFormatter(doc_operstate, mdFh, mode="operstate")
+    documentFormatter(doc_operations, mdFh, mode="operations")
     mdFh.close()
-    resetDocJson()
+
 
 class OpenApiPlugin(plugin.PyangPlugin):
     def add_output_format(self, fmts):
@@ -274,11 +387,27 @@ class OpenApiPlugin(plugin.PyangPlugin):
             optparse.make_option("--md-outdir",
                                  type="string",
                                  dest="mdoutdir",
-                                 help="Output directory for markdown documents"),                                 
+                                 help="Output directory for markdown documents"),
             optparse.make_option("--with-md-doc",
                                  dest="with_md",
                                  action="store_true",
-                                 help="Generate markdown(.md) RESTCONF API documents"),                    
+                                 help="Generate markdown(.md) RESTCONF API documents"),
+            optparse.make_option("--with-oneof",
+                                 dest="no_oneof",
+                                 action="store_true",
+                                 help="Models Union/choice/case stmts using oneOf"),
+            optparse.make_option("--with-serverstub",
+                                 dest="with_serverstub",
+                                 action="store_true",
+                                 help="Generate Go-Server Stub code"),
+            optparse.make_option("--stub-outdir",
+                                 type="string",
+                                 dest="stub_outdir",
+                                 help="Output directory for server stubs"),
+            optparse.make_option("--template-dir",
+                                 type="string",
+                                 dest="template_dir",
+                                 help="stubs's template directory"),
         ]
         g = optparser.add_option_group("OpenApiPlugin options")
         g.add_options(optlist)
@@ -287,80 +416,104 @@ class OpenApiPlugin(plugin.PyangPlugin):
         ctx.implicit_errors = False
 
     def emit(self, ctx, modules, fd):
-    
-      global currentTag
-      global errorList
-      global warnList
 
-      if ctx.opts.outdir is None:
-        print("[Error]: Output directory is not mentioned")
-        sys.exit(2)
+        global currentTag
+        global errorList
+        global warnList
+        global globalCtx
 
-      if not os.path.exists(ctx.opts.outdir):
-        print("[Error]: Specified outdir: ", ctx.opts.outdir, " does not exists")
-        sys.exit(2)
+        if "OPENAPI_EXTENDED" in os.environ and ctx.opts.no_oneof is None:
+            if bool(os.environ["OPENAPI_EXTENDED"]):
+                ctx.opts.with_md = None
+                ctx.opts.no_oneof = True
 
-      for module in modules:
-        print("===> processing ", module.i_modulename)
-        if module.keyword == "submodule":
-            continue
-        resetSwaggerDict()
-        currentTag = module.i_modulename
-        walk_module(module)
-        # delete root '/' as we dont support it.
-            
-        if len(swaggerDict["paths"]) > 0:
-            if "/restconf/data/" in swaggerDict["paths"]:
-                del(swaggerDict["paths"]["/restconf/data/"])
+        globalCtx = ctx
+        global_fd = fd
 
-        if len(swaggerDict["paths"]) <= 0:
-            continue
+        if ctx.opts.outdir and not os.path.exists(ctx.opts.outdir):
+            print("[Error]: Specified outdir: ",
+                  ctx.opts.outdir, " does not exists")
+            sys.exit(2)
 
-        # check if file is same
-        yamlFn = ctx.opts.outdir + '/' + module.i_modulename + ".yaml"
-        code = ordered_dump(swaggerDict, Dumper=yaml.SafeDumper)
-        if os.path.isfile(yamlFn):
-            f=open(yamlFn,'r')
-            oldCode = f.read()
-            if (oldCode==code):
-                print('code unchanged.. skipping write for file:'+yamlFn)
-                f.close()
+        for module in modules:
+            if module.keyword == "submodule":
                 continue
-            else:
-                print('code changed.. overwriting file:'+yamlFn)
-                fout = open(yamlFn,'w')
-                fout.write(code)
-                fout.close()
-                mdGen(ctx, module)
-        else:        
-            with open(ctx.opts.outdir + '/' + module.i_modulename + ".yaml", "w") as spec:
-              spec.write(ordered_dump(swaggerDict, Dumper=yaml.SafeDumper))
-              mdGen(ctx, module)
-    
-      if len(warnList) > 0:
-          print("========= Warnings observed =======")
-          for warn in warnList:
-              print(warn)     
+            if ctx.opts.outdir:
+                print("===> processing %s ..." % (module.i_modulename))
+            resetSwaggerDict()
+            resetDocJson()
+            currentTag = module.i_modulename
+            walk_module(module)
+            # delete root '/' as we dont support it.
 
-      if len(errorList) > 0:
-          print("========= Errors observed =======")
-          for err in errorList:
-              print(err)
-          print("========= Exiting due to above Errors =======")
-          sys.exit(2)
+            if len(swaggerDict["paths"]) > 0:
+                if "/restconf/data/" in swaggerDict["paths"]:
+                    del(swaggerDict["paths"]["/restconf/data/"])
+
+            if len(swaggerDict["paths"]) <= 0:
+                continue
+
+            code = ordered_dump(
+                swaggerDict, Dumper=yaml.SafeDumper, default_flow_style=False)
+            if ctx.opts.outdir is None:
+                global_fd.write(code)
+                continue
+
+            yamlChanged = False
+            # check if file is same
+            yamlFn = ctx.opts.outdir + '/' + module.i_modulename + ".yaml"
+            if os.path.isfile(yamlFn):
+                f = open(yamlFn, 'r')
+                oldCode = f.read()
+                if (oldCode == code):
+                    print('code unchanged.. skipping write for file:'+yamlFn)
+                    f.close()
+                    continue
+                else:
+                    print('code changed.. overwriting file:'+yamlFn)
+                    fout = open(yamlFn, 'w')
+                    fout.write(code)
+                    fout.close()
+                    mdGen(ctx, module)
+                    yamlChanged = True
+            else:
+                with open(ctx.opts.outdir + '/' + module.i_modulename + ".yaml", "w") as spec:
+                    spec.write(ordered_dump(
+                        swaggerDict, Dumper=yaml.SafeDumper, default_flow_style=False))
+                    mdGen(ctx, module)
+                    yamlChanged = True
+
+            if yamlChanged and ctx.opts.with_serverstub:
+                generateServerStubs(ctx, module.i_modulename)
+
+        if len(warnList) > 0:
+            print("========= Warnings observed =======")
+            for warn in warnList:
+                print(warn)
+
+        if len(errorList) > 0:
+            print("========= Errors observed =======")
+            for err in errorList:
+                print(err)
+            print("========= Exiting due to above Errors =======")
+            sys.exit(2)
+
 
 def walk_module(module):
     for child in module.i_children:
         walk_child(child)
 
+
 def add_swagger_tag(module):
     if module.i_modulename not in moduleDict:
         moduleDict[module.i_modulename] = OrderedDict()
-        moduleDict[module.i_modulename]["name"] =  module.i_modulename
-        moduleDict[module.i_modulename]["description"] = "Operations for " + module.i_modulename
+        moduleDict[module.i_modulename]["name"] = module.i_modulename
+        moduleDict[module.i_modulename]["description"] = "Operations for " + \
+            module.i_modulename
         swagger_tags.append(moduleDict[module.i_modulename])
     else:
         return
+
 
 def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, xParamsList=[], jsonPayload=OrderedDict()):
 
@@ -368,12 +521,12 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, x
     verbPathStr = pathstr
     global currentTag
     global docJson
-    
+
     docObj = None
     if child.i_config:
         docObj = docJson["config"]
     else:
-        docObj = docJson["operstate"] 
+        docObj = docJson["operstate"]
 
     if verb == "post":
         pathstrList = pathstr.split('/')
@@ -399,15 +552,13 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, x
     if verb not in swaggerDict["paths"][verbPathStr]:
         swaggerDict["paths"][verbPathStr][verb] = OrderedDict()
         swaggerDict["paths"][verbPathStr][verb]["tags"] = [currentTag]
-        if verb != "delete" and verb != "get":
-            swaggerDict["paths"][verbPathStr][verb]["consumes"] = ["application/yang-data+json"]
-        swaggerDict["paths"][verbPathStr][verb]["produces"] = ["application/yang-data+json"]
         swaggerDict["paths"][verbPathStr][verb]["parameters"] = []
-        swaggerDict["paths"][verbPathStr][verb]["responses"] = copy.deepcopy(merge_two_dicts(responses, verb_responses[verb]))
+        swaggerDict["paths"][verbPathStr][verb]["responses"] = copy.deepcopy(
+            merge_two_dicts(responses, verb_responses[verb]))
         firstEncounter = False
 
     haveXParams = False
-    tempParamsList = []     
+    tempParamsList = []
     for entry in xParamsList:
         if entry["yangName"] not in tempParamsList:
             tempParamsList.append(entry["yangName"])
@@ -416,8 +567,9 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, x
             break
 
     if haveXParams:
-        swaggerDict["paths"][verbPathStr][verb]["x-params"] = {"varMapping":copy.deepcopy(xParamsList)}
-    
+        swaggerDict["paths"][verbPathStr][verb]["x-params"] = {
+            "varMapping": copy.deepcopy(xParamsList)}
+
     if not child.i_config:
         swaggerDict["paths"][verbPathStr][verb]["x-config"] = "false"
 
@@ -429,15 +581,23 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, x
             swaggerDict["paths"][verbPathStr][verb]["operationId"] = operId
 
         opId = swaggerDict["paths"][verbPathStr][verb]["operationId"]
-        
+        swaggerDict["paths"][verbPathStr][verb]["x-operationIdCamelCase"] = snake_to_camel(
+            opId)
+        OpIdDict[swaggerDict["paths"][verbPathStr][verb]["x-operationIdCamelCase"]] = {
+            "path": verbPathStr, "method": verb, "obj": swaggerDict["paths"][verbPathStr][verb]}
+
+        if verbPathStr == "/restconf/data/" and verb == "post":
+            del(OpIdDict[swaggerDict["paths"][verbPathStr]
+                         [verb]["x-operationIdCamelCase"]])
+
         desc = child.search_one('description')
         if desc is None:
             desc = ''
         else:
             desc = desc.arg
         docObj[verbPathStr]["description"] = copy.deepcopy(desc)
-        desc = "OperationId: " + opId + "\n" + desc        
-        swaggerDict["paths"][verbPathStr][verb]["description"] = desc        
+        desc = "OperationId: " + opId + "\n" + desc
+        swaggerDict["paths"][verbPathStr][verb]["description"] = desc
 
     else:
         opId = swaggerDict["paths"][verbPathStr][verb]["operationId"]
@@ -451,59 +611,60 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, x
     if not firstEncounter:
         for meta in metadata:
             metaTag = OrderedDict()
-            metaTag["in"] = "path"
             metaTag["name"] = meta["name"]
+            metaTag["in"] = "path"
             metaTag["required"] = True
-            metaTag["type"] = meta["type"]
-            if 'enums' in meta:
-                metaTag["enum"] = meta["enums"]
-            if hasattr(meta,'format'):
-                if meta["format"] != "":
-                    metaTag["format"] = meta["format"]
+            metaTag["schema"] = copy.deepcopy(meta["schema"])
             metaTag["description"] = meta["desc"]
             verbPath["parameters"].append(metaTag)
             if not paramsFilled:
                 doc_uriPath["parameters"].append(copy.deepcopy(metaTag))
 
-
     if verb in ["post", "put", "patch"]:
         if not firstEncounter:
             bodyTag = OrderedDict()
-            bodyTag["in"] = "body"
-            bodyTag["name"] = "body"
+            bodyTag["content"] = OrderedDict()
             bodyTag["required"] = True
-            bodyTag["schema"] = OrderedDict()
+            bodyTag["content"]["application/yang-data+json"] = OrderedDict()
+            bodyTag["content"]["application/yang-data+json"]["schema"] = OrderedDict()
             operationDefnName = opId
-            swaggerDict["definitions"][operationDefnName] = OrderedDict()
-            swaggerDict["definitions"][operationDefnName]["allOf"] = []
-            bodyTag["schema"]["$ref"] = "#/definitions/" + operationDefnName
-            verbPath["parameters"].append(bodyTag)
-            swaggerDict["definitions"][operationDefnName]["allOf"].append({"$ref" : "#/definitions/" + defName})
+            schemasDict[operationDefnName] = OrderedDict()
+            schemasDict[operationDefnName]["allOf"] = []
+            bodyTag["content"]["application/yang-data+json"]["schema"]["$ref"] = "#/components/schemas/" + operationDefnName
+            verbPath["requestBody"] = bodyTag
+            schemasDict[operationDefnName]["allOf"].append(
+                {"$ref": "#/components/schemas/" + defName})
             doc_verbPath["body"] = copy.deepcopy(jsonPayload)
         else:
-            bodyTag = None
-            for entry in verbPath["parameters"]:
-                if entry["name"] == "body" and entry["in"] == "body":
-                    bodyTag = entry
-                    break
-            operationDefnName = bodyTag["schema"]["$ref"].split('/')[-1]
-            swaggerDict["definitions"][operationDefnName]["allOf"].append({"$ref" : "#/definitions/" + defName})
-            doc_verbPath["body"] = merge_two_dicts(doc_verbPath["body"], copy.deepcopy(jsonPayload))
+            bodyTag = verbPath["requestBody"]
+            operationDefnName = bodyTag["content"]["application/yang-data+json"]["schema"]["$ref"].split(
+                '/')[-1]
+            schemasDict[operationDefnName]["allOf"].append(
+                {"$ref": "#/components/schemas/" + defName})
+            doc_verbPath["body"] = merge_two_dicts(
+                doc_verbPath["body"], copy.deepcopy(jsonPayload))
 
     if verb == "get":
-        verbPath["responses"]["200"]["schema"] = OrderedDict()
-        verbPath["responses"]["200"]["schema"]["$ref"] = "#/definitions/" + defName
+        verbPath["responses"]["200"]["content"]["application/yang-data+json"] = OrderedDict()
+        verbPath["responses"]["200"]["content"]["application/yang-data+json"]["schema"] = OrderedDict()
+        verbPath["responses"]["200"]["content"]["application/yang-data+json"]["schema"]["$ref"] = "#/components/schemas/" + defName
         doc_verbPath["body"] = copy.deepcopy(jsonPayload)
 
         # Generate HEAD requests
         uriPath["head"] = copy.deepcopy(verbPath)
-        uriPath["head"]["operationId"] = 'head_' + verbPath["operationId"][4:] #taking after get_
-        uriPath["head"]["description"] = uriPath["head"]["description"].replace(verbPath["operationId"],uriPath["head"]["operationId"])
-        del(uriPath["head"]["responses"]["200"]["schema"])
-        del(uriPath["head"]["produces"])
-    
+        uriPath["head"]["operationId"] = 'head_' + \
+            verbPath["operationId"][4:]  # taking after get_
+        uriPath["head"]["x-operationIdCamelCase"] = snake_to_camel(
+            uriPath["head"]["operationId"])
+        OpIdDict[uriPath["head"]["x-operationIdCamelCase"]
+                 ] = {"path": verbPathStr, "method": "head", "obj": uriPath["head"]}
+        uriPath["head"]["description"] = uriPath["head"]["description"].replace(
+            verbPath["operationId"], uriPath["head"]["operationId"])
+        del(uriPath["head"]["responses"]["200"]["content"])
+
     if verb == "delete":
         doc_verbPath["body"] = OrderedDict()
+
 
 def handle_rpc(child, actXpath, pathstr):
     global currentTag
@@ -515,43 +676,50 @@ def handle_rpc(child, actXpath, pathstr):
     DefName = shortenNodeName(child, customName)
     opId = "rpc_" + DefName
     add_swagger_tag(child.i_module)
-    
+
     jsonPayload_input = OrderedDict()
     # build input payload
-    input_payload = OrderedDict()       
+    input_payload = OrderedDict()
     input_child = child.search_one('input', None, child.i_children)
     if input_child is None:
-        print("There is no input node for RPC ", "Xpath: ", actXpath)    
-    build_payload(input_child, input_payload, pathstr, True, actXpath, True, False, [], jsonPayload_input)    
+        print("There is no input node for RPC ", "Xpath: ", actXpath)
+    build_payload(input_child, input_payload, pathstr, True,
+                  actXpath, True, False, [], jsonPayload_input)
     input_Defn = "rpc_input_" + DefName
-    swaggerDict["definitions"][input_Defn] = OrderedDict()
-    swaggerDict["definitions"][input_Defn]["type"] = "object"
-    swaggerDict["definitions"][input_Defn]["properties"] = copy.deepcopy(input_payload)
+    schemasDict[input_Defn] = OrderedDict()
+    schemasDict[input_Defn]["type"] = "object"
+    schemasDict[input_Defn]["properties"] = copy.deepcopy(input_payload)
 
     # build output payload
     jsonPayload_output = OrderedDict()
-    output_payload = OrderedDict()       
+    output_payload = OrderedDict()
     output_child = child.search_one('output', None, child.i_children)
     if output_child is None:
         print("There is no output node for RPC ", "Xpath: ", actXpath)
-    build_payload(output_child, output_payload, pathstr, True, actXpath, True, False, [], jsonPayload_output) 
+    build_payload(output_child, output_payload, pathstr, True,
+                  actXpath, True, False, [], jsonPayload_output)
     output_Defn = "rpc_output_" + DefName
-    swaggerDict["definitions"][output_Defn] = OrderedDict()
-    swaggerDict["definitions"][output_Defn]["type"] = "object"
-    swaggerDict["definitions"][output_Defn]["properties"] = copy.deepcopy(output_payload)        
+    schemasDict[output_Defn] = OrderedDict()
+    schemasDict[output_Defn]["type"] = "object"
+    schemasDict[output_Defn]["properties"] = copy.deepcopy(output_payload)
 
     if verbPathStr not in swaggerDict["paths"]:
         swaggerDict["paths"][verbPathStr] = OrderedDict()
-    
+
     if verbPathStr not in docObj:
         docObj[verbPathStr] = OrderedDict()
-    
+
     swaggerDict["paths"][verbPathStr][verb] = OrderedDict()
     swaggerDict["paths"][verbPathStr][verb]["tags"] = [currentTag]
-    
+
     # Set Operation ID
     swaggerDict["paths"][verbPathStr][verb]["operationId"] = opId
-    
+    swaggerDict["paths"][verbPathStr][verb]["x-operationIdCamelCase"] = snake_to_camel(
+        opId)
+    OpIdDict[swaggerDict["paths"][verbPathStr][verb]["x-operationIdCamelCase"]] = {
+        "path": verbPathStr, "method": "post", "obj": swaggerDict["paths"][verbPathStr][verb]}
+    swaggerDict["paths"][verbPathStr][verb]["x-rpc"] = True
+
     # Set Description
     desc = child.search_one('description')
     if desc is None:
@@ -559,57 +727,67 @@ def handle_rpc(child, actXpath, pathstr):
     else:
         desc = desc.arg
     docObj[verbPathStr]["description"] = copy.deepcopy(desc)
-    desc = "OperationId: " + opId + "\n" + desc        
+    desc = "OperationId: " + opId + "\n" + desc
     swaggerDict["paths"][verbPathStr][verb]["description"] = desc
     verbPath = swaggerDict["paths"][verbPathStr][verb]
-    
+
     # Request payload
-    if len(input_payload[child.i_module.i_modulename + ':input']['properties']) > 0:
-        verbPath["parameters"] = []    
-        verbPath["consumes"] = ["application/yang-data+json"]
-        bodyTag = OrderedDict()
-        bodyTag["in"] = "body"
-        bodyTag["name"] = "body"
-        bodyTag["required"] = True
+    if len(input_payload[child.i_module.i_modulename + ':input']) > 0:
+        verbPath["requestBody"] = OrderedDict()
+        verbPath["requestBody"]["content"] = OrderedDict()
+        verbPath["requestBody"]["required"] = True
+        verbPath["requestBody"]["content"]["application/yang-data+json"] = OrderedDict()
+        bodyTag = verbPath["requestBody"]["content"]["application/yang-data+json"]
         bodyTag["schema"] = OrderedDict()
-        bodyTag["schema"]["$ref"] = "#/definitions/" + input_Defn
-        verbPath["parameters"].append(bodyTag)
+        bodyTag["schema"]["$ref"] = "#/components/schemas/" + input_Defn
 
     # Response payload
-    verbPath["responses"] = copy.deepcopy(merge_two_dicts(responses, verb_responses["rpc"]))        
-    if len(output_payload[child.i_module.i_modulename + ':output']['properties']) > 0:
-        verbPath["produces"] = ["application/yang-data+json"]    
-        verbPath["responses"]["204"]["schema"] = OrderedDict()    
-        verbPath["responses"]["204"]["schema"]["$ref"] = "#/definitions/" + output_Defn    
+    verbPath["responses"] = copy.deepcopy(
+        merge_two_dicts(responses, verb_responses["rpc"]))
+    if len(output_payload[child.i_module.i_modulename + ':output']) > 0:
+        verbPath["responses"]["204"]["content"] = OrderedDict()
+        verbPath["responses"]["204"]["content"]["application/yang-data+json"] = OrderedDict()
+        verbPath["responses"]["204"]["content"]["application/yang-data+json"]["schema"] = OrderedDict()
+        verbPath["responses"]["204"]["content"]["application/yang-data+json"]["schema"]["$ref"] = "#/components/schemas/" + output_Defn
 
     docObj[verbPathStr]["parameters"] = []
-    docObj[verbPathStr]["input"] = copy.deepcopy(jsonPayload_input)   
-    docObj[verbPathStr]["output"] = copy.deepcopy(jsonPayload_output)   
+    docObj[verbPathStr]["input"] = copy.deepcopy(jsonPayload_input)
+    docObj[verbPathStr]["output"] = copy.deepcopy(jsonPayload_output)
+
 
 def walk_child(child):
     global XpathToBodyTagDict
-    customName =  None
+    global XpathToBodyTagDict_with_config_false
+    customName = None
 
     actXpath = statements.mk_path_str(child, True)
     metadata = []
     keyNodesInPath = []
     paramsList = []
-    pathstr = mk_path_refine(child, metadata, keyNodesInPath, False, paramsList)
-        
+    pathstr = mk_path_refine(
+        child, metadata, keyNodesInPath, False, paramsList)
+
     if actXpath in keysToLeafRefObjSet:
         return
 
     if child.keyword == "rpc":
         add_swagger_tag(child.i_module)
         handle_rpc(child, actXpath, pathstr)
-        return 
+        return
 
     if child.keyword in ["list", "container", "leaf", "leaf-list"]:
-        payload = OrderedDict() 
-        jsonPayload = OrderedDict()   
+        payload = OrderedDict()
+        jsonPayload = OrderedDict()
+        payload_get = OrderedDict()
+        json_payload_get = OrderedDict()
 
         add_swagger_tag(child.i_module)
-        build_payload(child, payload, pathstr, True, actXpath, True, False, [], jsonPayload)
+        if actXpath in XpathToBodyTagDict:
+            payload = XpathToBodyTagDict[actXpath]["payload"]
+            jsonPayload = XpathToBodyTagDict[actXpath]["payloadJson"]
+        else:
+            build_payload(child, payload, pathstr, True,
+                          actXpath, True, False, [], jsonPayload)
 
         if len(payload) == 0 and child.i_config == True:
             return
@@ -617,7 +795,8 @@ def walk_child(child):
         if child.keyword == "leaf" or child.keyword == "leaf-list":
             if hasattr(child, 'i_is_key'):
                 if child.i_leafref is not None:
-                    listKeyPath = statements.mk_path_str(child.i_leafref_ptr[0], True)
+                    listKeyPath = statements.mk_path_str(
+                        child.i_leafref_ptr[0], True)
                     if listKeyPath not in keysToLeafRefObjSet:
                         keysToLeafRefObjSet.add(listKeyPath)
                 return
@@ -625,75 +804,95 @@ def walk_child(child):
         customName = getOpId(child)
         defName = shortenNodeName(child, customName)
 
-        if child.i_config == False:   
+        if child.i_config == False:
             payload_get = OrderedDict()
             json_payload_get = OrderedDict()
-            build_payload(child, payload_get, pathstr, True, actXpath, True, True, [], json_payload_get)
+            if actXpath in XpathToBodyTagDict_with_config_false:
+                payload_get = XpathToBodyTagDict_with_config_false[actXpath]["payload"]
+                json_payload_get = XpathToBodyTagDict_with_config_false[actXpath]["payloadJson"]
+            else:
+                build_payload(child, payload_get, pathstr, True,
+                              actXpath, True, True, [], json_payload_get)
+
             if len(payload_get) == 0:
-                return  
+                return
 
             defName_get = "get" + '_' + defName
-            swaggerDict["definitions"][defName_get] = OrderedDict()
-            swaggerDict["definitions"][defName_get]["type"] = "object"
-            swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)
-            swagger_it(child, defName_get, pathstr, payload_get, metadata, "get", defName_get, paramsList, json_payload_get)
+            schemasDict[defName_get] = OrderedDict()
+            schemasDict[defName_get]["type"] = "object"
+            schemasDict[defName_get]["properties"] = copy.deepcopy(payload_get)
+            swagger_it(child, defName_get, pathstr, payload_get, metadata,
+                       "get", defName_get, paramsList, json_payload_get)
         else:
-            swaggerDict["definitions"][defName] = OrderedDict()
-            swaggerDict["definitions"][defName]["type"] = "object"
-            swaggerDict["definitions"][defName]["properties"] = copy.deepcopy(payload)            
+            schemasDict[defName] = OrderedDict()
+            schemasDict[defName]["type"] = "object"
+            schemasDict[defName]["properties"] = copy.deepcopy(payload)
 
             for verb in verbs:
                 if child.keyword == "leaf-list":
                     metadata_leaf_list = []
                     keyNodesInPath_leaf_list = []
                     paramsLeafList = []
-                    pathstr_leaf_list = mk_path_refine(child, metadata_leaf_list, keyNodesInPath_leaf_list, True, paramsLeafList)                    
+                    pathstr_leaf_list = mk_path_refine(
+                        child, metadata_leaf_list, keyNodesInPath_leaf_list, True, paramsLeafList)
 
                 if verb == "get":
                     payload_get = OrderedDict()
                     json_payload_get = OrderedDict()
-                    build_payload(child, payload_get, pathstr, True, actXpath, True, True, [], json_payload_get)
+                    if actXpath in XpathToBodyTagDict_with_config_false:
+                        payload_get = XpathToBodyTagDict_with_config_false[actXpath]["payload"]
+                        json_payload_get = XpathToBodyTagDict_with_config_false[actXpath]["payloadJson"]
+                    else:
+                        build_payload(child, payload_get, pathstr, True,
+                                      actXpath, True, True, [], json_payload_get)
+
                     if len(payload_get) == 0:
-                        continue  
+                        continue
                     defName_get = "get" + '_' + defName
-                    swaggerDict["definitions"][defName_get] = OrderedDict()
-                    swaggerDict["definitions"][defName_get]["type"] = "object"
-                    swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)
-                    swagger_it(child, defName_get, pathstr, payload_get, metadata, verb, defName_get, paramsList, json_payload_get)
+                    schemasDict[defName_get] = OrderedDict()
+                    schemasDict[defName_get]["type"] = "object"
+                    schemasDict[defName_get]["properties"] = copy.deepcopy(
+                        payload_get)
+                    swagger_it(child, defName_get, pathstr, payload_get,
+                               metadata, verb, defName_get, paramsList, json_payload_get)
 
                     if child.keyword == "leaf-list":
                         defName_get_leaf_list = "get" + '_llist_' + defName
-                        swagger_it(child, defName_get, pathstr_leaf_list, payload_get, metadata_leaf_list, verb, defName_get_leaf_list, paramsLeafList, json_payload_get)
+                        swagger_it(child, defName_get, pathstr_leaf_list, payload_get, metadata_leaf_list,
+                                   verb, defName_get_leaf_list, paramsLeafList, json_payload_get)
 
                     continue
-                
+
                 if verb == "post" and child.keyword == "list":
                     continue
-                
+
                 if verb == "delete" and child.keyword == "container":
                     # Check to see if any of the child is part of
                     # key list, if so skip delete operation
-                    if isUriKeyInPayload(child,keyNodesInPath):
+                    if isUriKeyInPayload(child, keyNodesInPath):
                         continue
 
-                swagger_it(child, defName, pathstr, payload, metadata, verb, False, paramsList, jsonPayload)
+                swagger_it(child, defName, pathstr, payload,
+                           metadata, verb, False, paramsList, jsonPayload)
                 if verb == "delete" and child.keyword == "leaf-list":
                     defName_del_leaf_list = "del" + '_llist_' + defName
-                    swagger_it(child, defName, pathstr_leaf_list, payload, metadata_leaf_list, verb, defName_del_leaf_list, paramsLeafList, jsonPayload)
+                    swagger_it(child, defName, pathstr_leaf_list, payload, metadata_leaf_list,
+                               verb, defName_del_leaf_list, paramsLeafList, jsonPayload)
 
-        if  child.keyword == "list":
+        if child.keyword == "list":
             listMetaData = copy.deepcopy(metadata)
             listparamsList = copy.deepcopy(paramsList)
-            walk_child_for_list_base(child,actXpath,pathstr, listMetaData, defName, listparamsList)
+            walk_child_for_list_base(payload, jsonPayload, payload_get,
+                                     json_payload_get, child, actXpath, pathstr, listMetaData,
+                                     defName, listparamsList)
 
     if hasattr(child, 'i_children'):
         for ch in child.i_children:
             walk_child(ch)
 
-def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=None, paramsList=[]):
 
-    payload = OrderedDict()
-    jsonPayload = OrderedDict()
+def walk_child_for_list_base(payload, jsonPayload, payload_get, json_payload_get, child, actXpath, pathstr, metadata, nonBaseDefName=None, paramsList=[]):
+
     pathstrList = pathstr.split('/')
 
     lastNode = pathstrList[-1]
@@ -712,8 +911,7 @@ def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=
         if len(paramsList) > 0:
             paramsList.pop()
 
-    add_swagger_tag(child.i_module)    
-    build_payload(child, payload, pathstr, False, "", True, False, [], jsonPayload)
+    add_swagger_tag(child.i_module)
 
     if len(payload) == 0 and child.i_config == True:
         return
@@ -723,53 +921,63 @@ def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=
     defName = "list"+'_'+defName
 
     if child.i_config == False:
-        
-        payload_get = OrderedDict()
-        json_payload_get = OrderedDict()
-        build_payload(child, payload_get, pathstr, False, "", True, True, [], json_payload_get)
-        
         if len(payload_get) == 0:
             return
 
         defName_get = "get" + '_' + defName
         if nonBaseDefName is not None:
-            swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get, metadata, "get", defName_get, paramsList, json_payload_get)
+            swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get,
+                       metadata, "get", defName_get, paramsList, json_payload_get)
         else:
-            swaggerDict["definitions"][defName_get] = OrderedDict()
-            swaggerDict["definitions"][defName_get]["type"] = "object"
-            swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)            
-            swagger_it(child, defName_get, pathstr, payload_get, metadata, "get", defName_get, paramsList, json_payload_get)
+            schemasDict[defName_get] = OrderedDict()
+            schemasDict[defName_get]["type"] = "object"
+            schemasDict[defName_get]["properties"] = copy.deepcopy(payload_get)
+            swagger_it(child, defName_get, pathstr, payload_get, metadata,
+                       "get", defName_get, paramsList, json_payload_get)
     else:
         if nonBaseDefName is None:
-            swaggerDict["definitions"][defName] = OrderedDict()
-            swaggerDict["definitions"][defName]["type"] = "object"
-            swaggerDict["definitions"][defName]["properties"] = copy.deepcopy(payload)        
+            schemasDict[defName] = OrderedDict()
+            schemasDict[defName]["type"] = "object"
+            schemasDict[defName]["properties"] = copy.deepcopy(payload)
 
         for verb in verbs:
             if verb == "get":
-                payload_get = OrderedDict()   
-                json_payload_get = OrderedDict()                
-                build_payload(child, payload_get, pathstr, False, "", True, True, [], json_payload_get)
-                
+                # payload_get = OrderedDict()
+                # json_payload_get = OrderedDict()
+                # build_payload(child, payload_get, pathstr, False, "", True, True, [], json_payload_get)
+
                 if len(payload_get) == 0:
                     continue
 
                 defName_get = "get" + '_' + defName
                 if nonBaseDefName is not None:
-                    swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get, metadata, verb, defName_get, paramsList, json_payload_get)
+                    swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get,
+                               metadata, verb, defName_get, paramsList, json_payload_get)
                 else:
-                    swaggerDict["definitions"][defName_get] = OrderedDict()
-                    swaggerDict["definitions"][defName_get]["type"] = "object"
-                    swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)
-                    swagger_it(child, defName_get, pathstr, payload_get, metadata, verb, defName_get, paramsList, json_payload_get)
+                    schemasDict[defName_get] = OrderedDict()
+                    schemasDict[defName_get]["type"] = "object"
+                    schemasDict[defName_get]["properties"] = copy.deepcopy(
+                        payload_get)
+                    swagger_it(child, defName_get, pathstr, payload_get,
+                               metadata, verb, defName_get, paramsList, json_payload_get)
                 continue
-            
-            if nonBaseDefName is not None:
-                swagger_it(child, nonBaseDefName, pathstr, payload, metadata, verb, verb + '_' + defName, paramsList, jsonPayload)
-            else:
-                swagger_it(child, defName, pathstr, payload, metadata, verb, verb + '_' + defName, paramsList, jsonPayload)
 
-def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", firstCall=False, config_false=False, moduleList=[], jsonPayloadDict=OrderedDict()):
+            if nonBaseDefName is not None:
+                swagger_it(child, nonBaseDefName, pathstr, payload, metadata,
+                           verb, verb + '_' + defName, paramsList, jsonPayload)
+            else:
+                swagger_it(child, defName, pathstr, payload, metadata,
+                           verb, verb + '_' + defName, paramsList, jsonPayload)
+
+
+def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", firstCall=False, config_false=False, moduleList=[], jsonPayloadDict=OrderedDict(), parentNode=None):
+
+    global XpathToBodyTagDict
+    global XpathToBodyTagDict_with_config_false
+    xpathToNodeDict = XpathToBodyTagDict
+    if config_false:
+        xpathToNodeDict = XpathToBodyTagDict_with_config_false
+    child_xpath = statements.mk_path_str(child, True)
 
     nodeModuleName = child.i_module.i_modulename
     if nodeModuleName not in moduleList:
@@ -778,19 +986,22 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
 
     global keysToLeafRefObjSet
 
-    if child.i_config == False and not config_false:      
+    if child.i_config == False and not config_false:
         return  # temporary
 
-    chs=[]
+    chs = []
     try:
         chs = [ch for ch in child.i_children
-           if ch.keyword in statements.data_definition_keywords]
+               if ch.keyword in statements.data_definition_keywords]
     except:
         # do nothing as it could be due to i_children not present
         pass
 
     childJson = None
     payloadJson = None
+    nodeObj = None
+    nodeName = ""
+
     if child.keyword == "container" and len(chs) > 0:
         if firstCall:
             nodeName = child.i_module.i_modulename + ':' + child.arg
@@ -803,24 +1014,33 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
 
         jsonPayloadDict[nodeName] = OrderedDict()
         payloadJson = jsonPayloadDict[nodeName]
-    
+        nodeObj = payloadDict[nodeName]
+
     elif child.keyword == "list" and len(chs) > 0:
         if firstCall:
             nodeName = child.i_module.i_modulename + ':' + child.arg
         else:
             nodeName = child.arg
         payloadDict[nodeName] = OrderedDict()
-        jsonPayloadDict[nodeName] = [OrderedDict()]      
+        jsonPayloadDict[nodeName] = [OrderedDict()]
         returnJson = None
         payloadreturnJson = None
-        
+
         payloadDict[nodeName]["type"] = "array"
         payloadDict[nodeName]["items"] = OrderedDict()
         payloadDict[nodeName]["items"]["type"] = "object"
         payloadDict[nodeName]["items"]["required"] = []
 
         for listKey in child.i_key:
-            payloadDict[nodeName]["items"]["required"].append(listKey.arg)            
+            payloadDict[nodeName]["items"]["required"].append(listKey.arg)
+
+        minStmt = child.search_one('min-elements')
+        if minStmt:
+            payloadDict[nodeName]["items"]["minItems"] = int(minStmt.arg)
+
+        maxStmt = child.search_one('max-elements')
+        if maxStmt:
+            payloadDict[nodeName]["items"]["maxItems"] = int(maxStmt.arg)
 
         payloadDict[nodeName]["items"]["properties"] = OrderedDict()
         returnJson = payloadDict[nodeName]["items"]["properties"]
@@ -828,7 +1048,7 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
 
         childJson = returnJson
         payloadJson = payloadreturnJson
-
+        nodeObj = payloadDict[nodeName]["items"]
 
     elif child.keyword == "leaf":
 
@@ -838,25 +1058,24 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
             nodeName = child.arg
         payloadDict[nodeName] = OrderedDict()
         jsonPayloadDict[nodeName] = OrderedDict()
-        typeInfo = getType(child)
-        enums = None
-        if isinstance(typeInfo, tuple):
-            enums = typeInfo[1]
-            typeInfo = typeInfo[0]
-        
-        if 'type' in typeInfo:
-            dType = typeInfo["type"]
-        else:
-            dType = "string"
-        
-        payloadDict[nodeName]["type"] = dType
-        if enums is not None:
-            payloadDict[nodeName]["enum"] = enums
+        typeInfo = copy.deepcopy(getType(child, []))
 
-        if 'format' in typeInfo:
-            payloadDict[nodeName]["format"] = typeInfo["format"]
-        
-        jsonPayloadDict[nodeName] = dType       
+        defaultStmt = child.search_one('default')
+        if defaultStmt:
+            typeInfo["default"] = defaultStmt.arg if not defaultStmt.arg.isdigit(
+            ) else int(defaultStmt.arg)
+
+        if statements.is_mandatory_node(child) and not firstCall:
+            if 'required' not in parentNode:
+                parentNode["required"] = [child.arg]
+            else:
+                parentNode["required"].append(child.arg)
+
+        payloadDict[nodeName] = typeInfo
+        if 'oneOf' in typeInfo:
+            jsonPayloadDict[nodeName] = getOneOfTypesOred(typeInfo['oneOf'])
+        else:
+            jsonPayloadDict[nodeName] = typeInfo['x-yang-type']
 
     elif child.keyword == "leaf-list":
 
@@ -870,30 +1089,36 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
         payloadDict[nodeName]["type"] = "array"
         payloadDict[nodeName]["items"] = OrderedDict()
 
-        typeInfo = getType(child)
-        enums = None
-        if isinstance(typeInfo, tuple):
-            enums = typeInfo[1]
-            typeInfo = typeInfo[0]
+        typeInfo = copy.deepcopy(getType(child, []))
 
-        if 'type' in typeInfo:
-            dType = typeInfo["type"]
+        minStmt = child.search_one('min-elements')
+        if minStmt:
+            typeInfo["minItems"] = int(minStmt.arg)
+
+        maxStmt = child.search_one('max-elements')
+        if maxStmt:
+            typeInfo["maxItems"] = int(maxStmt.arg)
+
+        payloadDict[nodeName]["items"] = typeInfo
+        if 'oneOf' in typeInfo:
+            jsonPayloadDict[nodeName] = [getOneOfTypesOred(typeInfo['oneOf'])]
         else:
-            dType = "string"
-        
-        payloadDict[nodeName]["items"]["type"] = dType   
-        if enums is not None:
-            payloadDict[nodeName]["items"]["enum"] = enums           
+            jsonPayloadDict[nodeName] = [typeInfo["x-yang-type"]]
 
-        if 'format' in typeInfo:
-            payloadDict[nodeName]["items"]["format"] = typeInfo["format"]   
+    elif child.keyword == "choice":
+        if globalCtx.opts.no_oneof is not None:
+            parentNode["oneOf"] = []
+            payloadJson = jsonPayloadDict
+        else:
+            childJson = payloadDict
+            payloadJson = jsonPayloadDict
+            nodeObj = parentNode
 
-        jsonPayloadDict[nodeName] = [dType]         
-
-    elif child.keyword == "choice" or child.keyword == "case":
+    elif child.keyword == "case":
         childJson = payloadDict
         payloadJson = jsonPayloadDict
-    
+        nodeObj = parentNode
+
     elif child.keyword == "input" or child.keyword == "output":
         if firstCall:
             nodeName = child.i_module.i_modulename + ':' + child.keyword
@@ -903,14 +1128,33 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
         payloadDict[nodeName] = OrderedDict()
         payloadDict[nodeName]["type"] = "object"
         payloadDict[nodeName]["properties"] = OrderedDict()
-        childJson = payloadDict[nodeName]["properties"]   
+        childJson = payloadDict[nodeName]["properties"]
 
-        jsonPayloadDict[nodeName] =  OrderedDict()  
+        jsonPayloadDict[nodeName] = OrderedDict()
         payloadJson = jsonPayloadDict[nodeName]
+        nodeObj = payloadDict[nodeName]
+
+    if (child.keyword == "container" and len(chs) > 0) or (child.keyword == "list" and len(chs) > 0) \
+        or child.keyword == "leaf" or child.keyword == "leaf-list" \
+            or child.keyword == "input" or child.keyword == "output":
+        xpathToNodeDict[child_xpath] = {
+            "payload": {child.i_module.i_modulename + ':' + child.arg: payloadDict[nodeName]},
+            "payloadJson": {child.i_module.i_modulename + ':' + child.arg: jsonPayloadDict[nodeName]}
+        }
 
     if hasattr(child, 'i_children'):
         for ch in child.i_children:
-            build_payload(ch,childJson,uriPath, False, Xpath, False, config_false, copy.deepcopy(moduleList), payloadJson)
+            if child.keyword == "choice" and globalCtx.opts.no_oneof is not None:
+                oneOfEntry = OrderedDict()
+                oneOfEntry["type"] = "object"
+                oneOfEntry["properties"] = OrderedDict()
+                parentNode["oneOf"].append(oneOfEntry)
+                childJson = oneOfEntry["properties"]
+                nodeObj = oneOfEntry
+
+            build_payload(ch, childJson, uriPath, False, Xpath, False,
+                          config_false, copy.deepcopy(moduleList), payloadJson, nodeObj)
+
 
 def handleDuplicateParams(node, paramMeta={}):
     paramNamesList = paramMeta["paramNamesList"]
@@ -927,17 +1171,18 @@ def handleDuplicateParams(node, paramMeta={}):
             paramNameCount = paramNameCount + 1
             paramName = origParamName + str(paramNameCount-1)
         paramNamesList.append(paramName)
-    
+
     paramDictEntry["uriName"] = paramName
-    paramDictEntry["yangName"] = node.arg 
+    paramDictEntry["yangName"] = node.arg
     if paramName != node.arg:
         paramMeta["sameParams"] = True
     paramsList.append(paramDictEntry)
-    
+
     return paramName
 
+
 def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False, paramsList=[]):
-    paramMeta={}
+    paramMeta = {}
     paramMeta["paramNamesList"] = []
     paramMeta["paramsList"] = []
     paramMeta["sameParams"] = False
@@ -946,11 +1191,12 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False, paramsL
         """Returns the XPath path of the node"""
         if node.keyword in ['choice', 'case']:
             return mk_path(node.parent)
+
         def name(node):
             extra = ""
             if node.keyword == "leaf-list" and restconf_leaflist:
-                extraKeys = []     
-                paramName = handleDuplicateParams(node,paramMeta)
+                extraKeys = []
+                paramName = handleDuplicateParams(node, paramMeta)
                 extraKeys.append('{' + paramName + '}')
                 desc = node.search_one('description')
                 if desc is None:
@@ -960,18 +1206,23 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False, paramsL
                 metaInfo = OrderedDict()
                 metaInfo["desc"] = desc
                 metaInfo["name"] = paramName
-                metaInfo["type"] = "string"
-                metaInfo["format"] = ""
+                # metaInfo["type"] = "string"
+                # metaInfo["format"] = ""
+                typeInfo = copy.deepcopy(getType(node, []))
+                defaultStmt = node.search_one('default')
+                if defaultStmt:
+                    typeInfo["default"] = defaultStmt.arg
+                metaInfo["schema"] = typeInfo
                 metadata.append(metaInfo)
                 extra = ",".join(extraKeys)
 
             if node.keyword == "list":
-                extraKeys = []            
-                for index, list_key in enumerate(node.i_key):                    
+                extraKeys = []
+                for index, list_key in enumerate(node.i_key):
                     keyNodes.append(list_key)
                     if list_key.i_leafref is not None:
-                        keyNodes.append(list_key.i_leafref_ptr[0])                    
-                    paramName = handleDuplicateParams(list_key,paramMeta)
+                        keyNodes.append(list_key.i_leafref_ptr[0])
+                    paramName = handleDuplicateParams(list_key, paramMeta)
                     extraKeys.append('{' + paramName + '}')
                     desc = list_key.search_one('description')
                     if desc is None:
@@ -981,24 +1232,8 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False, paramsL
                     metaInfo = OrderedDict()
                     metaInfo["desc"] = desc
                     metaInfo["name"] = paramName
-                    typeInfo = getType(list_key)
-                    
-                    if isinstance(typeInfo, tuple):
-                        metaInfo["enums"] = typeInfo[1]
-                        typeInfo = typeInfo[0]
-
-                    if 'type' in typeInfo:
-                        dType = typeInfo["type"]
-                    else:
-                        dType = "string"
-                    
-                    metaInfo["type"] = dType
-
-                    if 'format' in typeInfo:
-                        metaInfo["format"] = typeInfo["format"]
-                    else:
-                        metaInfo["format"] = ""
-
+                    typeInfo = copy.deepcopy(getType(list_key, []))
+                    metaInfo["schema"] = typeInfo
                     metadata.append(metaInfo)
                 extra = ",".join(extraKeys)
 
@@ -1028,30 +1263,39 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False, paramsL
     xpath = "/".join(final_xpathList)
     if not xpath.startswith('/'):
         xpath = '/' + xpath
-    
+
     if paramMeta["sameParams"]:
         for entry in paramMeta["paramsList"]:
             paramsList.append(copy.deepcopy(entry))
 
     return xpath
 
-def handle_leafref(node,xpath):
-    path_type_spec = node.i_leafref
-    target_node = path_type_spec.i_target_node        
+
+def handle_leafref(node, typeNodes):
+    target_node = None
+    try:
+        path_type_spec = node.i_leafref
+    except:
+        if node.keyword == "type" and node.arg == "leafref":
+            target_node = find_target_node(globalCtx, node.i_type_spec.path_)
+    if target_node is None:
+        target_node = path_type_spec.i_target_node
     if target_node.keyword in ["leaf", "leaf-list"]:
-        return getType(target_node)
+        return copy.deepcopy(getType(target_node, typeNodes))
     else:
         print("leafref not pointing to leaf/leaflist")
         sys.exit(2)
 
+
 def getOpId(node):
     name = None
-    for substmt in node.substmts: 
+    for substmt in node.substmts:
         if substmt.keyword.__class__.__name__ == 'tuple':
             if substmt.keyword[0] == 'sonic-extensions':
                 if substmt.keyword[1] == 'openapi-opid':
                     name = substmt.arg
     return name
+
 
 def shortenNodeName(node, overridenName=None):
     global nodeDict
@@ -1061,11 +1305,11 @@ def shortenNodeName(node, overridenName=None):
     xpath = statements.mk_path_str(node, False)
     xpath_prefix = statements.mk_path_str(node, True)
     if overridenName is None:
-        name = node.i_module.i_modulename + xpath.replace('/','_')
+        name = node.i_module.i_modulename + xpath.replace('/', '_')
     else:
         name = overridenName
 
-    name = name.replace('-','_').lower()
+    name = name.replace('-', '_').lower()
     if name not in nodeDict:
         nodeDict[name] = xpath
     else:
@@ -1074,30 +1318,34 @@ def shortenNodeName(node, overridenName=None):
                 if xpath == nodeDict[name]:
                     break
                 name = node.i_module.i_modulename + '_' + name
-                name = name.replace('-','_').lower()
+                name = name.replace('-', '_').lower()
             nodeDict[name] = xpath
         else:
             if xpath != nodeDict[name]:
-                print("[Name collision] at ", xpath, " name: ", name, " is used, override using openapi-opid annotation")
+                print("[Name collision] at ", xpath, " name: ", name,
+                      " is used, override using openapi-opid annotation")
                 sys.exit(2)
     if len(name) > 150:
         if overridenName is None:
             # Generate unique hash
             mmhash = mmh3.hash(name, signed=False)
             name = node.i_module.i_modulename + str(mmhash)
-            name = name.replace('-','_').lower()
+            name = name.replace('-', '_').lower()
             nodeDict[name] = xpath
-            warnList.append("[Warn]: Using autogenerated shortened OperId for " + str(xpath_prefix) + " please provide unique manual input through openapi-opid annotation using deviation file if you want to override")
+            warnList.append("[Warn]: Using autogenerated shortened OperId for " + str(xpath_prefix) +
+                            " please provide unique manual input through openapi-opid annotation using deviation file if you want to override")
         if len(name) > 150:
-            errorList.append("[Error: ] OpID is too big for " + str(xpath_prefix) +" please provide unique manual input through openapi-opid annotation using deviation file")
+            errorList.append("[Error: ] OpID is too big for " + str(xpath_prefix) +
+                             " please provide unique manual input through openapi-opid annotation using deviation file")
     return name
+
 
 def getCamelForm(moName):
     hasHiphen = False
-    moName = moName.replace('_','-')
+    moName = moName.replace('_', '-')
     if '-' in moName:
         hasHiphen = True
-        
+
     while (hasHiphen):
         index = moName.find('-')
         if index != -1:
@@ -1107,56 +1355,157 @@ def getCamelForm(moName):
             # delete '-'
             del(moNameList[index])
             moName = "".join(moNameList)
-            
+
             if '-' in moName:
                 hasHiphen = True
             else:
-                hasHiphen = False           
+                hasHiphen = False
         else:
             break
 
-    return moName  
+    return moName
 
-def getType(node):
-    
+
+def getType(node, typeNodes=[]):
+
     global codegenTypesToYangTypesMap
-    xpath = statements.mk_path_str(node, True)
 
-    def resolveType(stmt, nodeType):
+    def resolveType(stmt, nodeType, typeNodes2):
         if nodeType == "string" \
-            or nodeType == "instance-identifier" \
-            or nodeType == "identityref":
-            return codegenTypesToYangTypesMap["string"]
-        elif nodeType == "enumeration":        
+                or nodeType == "instance-identifier" \
+                or nodeType == "identityref":
+
+            stringObj = copy.deepcopy(codegenTypesToYangTypesMap["string"])
+            # Handle pattern
+            if nodeType == "string":
+                patternStmtList = []
+                for typeStmt in typeNodes2:
+                    for patternStmt in typeStmt.search('pattern'):
+                        patternStmtList.append(patternStmt.arg)
+                if len(patternStmtList) > 0:
+                    stringObj["x-pattern"] = " && ".join(patternStmtList)
+
+                lengthStmtList = []
+                for typeStmt in typeNodes2:
+                    for lengthStmt in typeStmt.search('length'):
+                        lengthStmtList.append(lengthStmt.arg)
+
+                minVal = 0
+                maxVal = 0
+                for lengthEntry in lengthStmtList:
+                    if '..' in lengthEntry:
+                        leftVal, rightVal = list(
+                            filter(None, lengthEntry.split('..')))
+                        if leftVal != "min":
+                            if '|' in leftVal:
+                                leftVal = leftVal.split('|')[0]
+                            leftVal = int(leftVal)
+                            if minVal == 0:
+                                minVal = leftVal
+                            if leftVal < minVal:
+                                minVal = leftVal
+                        if rightVal != "max":
+                            if '|' in rightVal:
+                                rightVal = rightVal.split('|')[0]
+                            rightVal = int(rightVal)
+                            if maxVal == 0:
+                                maxVal = rightVal
+                            if rightVal > maxVal:
+                                maxVal = rightVal
+                if len(lengthStmtList) > 0:
+                    stringObj["x-length"] = " | ".join(lengthStmtList)
+                    if minVal != 0:
+                        stringObj["x-length"] = stringObj["x-length"].replace(
+                            'min', str(minVal))
+                        stringObj["minLength"] = minVal
+                    if maxVal != 0:
+                        stringObj["x-length"] = stringObj["x-length"].replace(
+                            'max', str(maxVal))
+                        stringObj["maxLength"] = maxVal
+            return copy.deepcopy(stringObj)
+
+        elif nodeType == "enumeration":
             enums = []
             for enum in stmt.substmts:
                 if enum.keyword == "enum":
                     enums.append(enum.arg)
-            return codegenTypesToYangTypesMap["string"], enums
+            enumObj = copy.deepcopy(codegenTypesToYangTypesMap["string"])
+            enumObj["enum"] = enums
+            return enumObj
         elif nodeType == "empty" or nodeType == "boolean":
-            return {"type": "boolean", "format": "boolean"}
-        elif nodeType == "leafref":            
-            return handle_leafref(node,xpath)
+            return {"type": "boolean", "format": "boolean", "x-yang-type": "boolean"}
+        elif nodeType == "leafref":
+            return handle_leafref(node, typeNodes2)
         elif nodeType == "union":
-            return codegenTypesToYangTypesMap["string"]
+            if globalCtx.opts.no_oneof is None:
+                stringObj = copy.deepcopy(codegenTypesToYangTypesMap["string"])
+                return stringObj
+            else:
+                unionObj = OrderedDict()
+                unionObj["oneOf"] = []
+                for unionStmt in stmt.search('type'):
+                    unionObj["oneOf"].append(copy.deepcopy(
+                        getType(unionStmt, typeNodes2)))
+                return copy.deepcopy(unionObj)
         elif nodeType == "decimal64":
-            return codegenTypesToYangTypesMap[nodeType]
+            return copy.deepcopy(codegenTypesToYangTypesMap[nodeType])
         elif nodeType in ['int8', 'int16', 'int32', 'int64',
-                  'uint8', 'uint16', 'uint32', 'uint64', 'binary', 'bits']:
-            return codegenTypesToYangTypesMap[nodeType]
+                          'uint8', 'uint16', 'uint32', 'uint64', 'binary', 'bits']:
+            intObj = copy.deepcopy(codegenTypesToYangTypesMap[nodeType])
+            rangeStmtList = []
+            for typeStmt in typeNodes2:
+                for rangeStmt in typeStmt.search('range'):
+                    rangeStmtList.append(rangeStmt.arg)
+
+            minVal = 0
+            maxVal = 0
+            for rangeEntry in rangeStmtList:
+                if '..' in rangeEntry:
+                    leftVal, rightVal = list(
+                        filter(None, rangeEntry.split('..')))
+                    if leftVal != "min":
+                        if '|' in leftVal:
+                            leftVal = leftVal.split('|')[0]
+                        leftVal = int(leftVal)
+                        if minVal == 0:
+                            minVal = leftVal
+                        if leftVal < minVal:
+                            minVal = leftVal
+                    if rightVal != "max":
+                        if '|' in rightVal:
+                            rightVal = rightVal.split('|')[0]
+                        rightVal = int(rightVal)
+                        if maxVal == 0:
+                            maxVal = rightVal
+                        if rightVal > maxVal:
+                            maxVal = rightVal
+            if len(rangeStmtList) > 0:
+                intObj["x-range"] = " | ".join(rangeStmtList)
+                if minVal != 0:
+                    intObj["x-range"] = intObj["x-range"].replace(
+                        'min', str(minVal))
+                    intObj["minimum"] = minVal
+                if maxVal != 0:
+                    intObj["x-range"] = intObj["x-range"].replace(
+                        'max', str(maxVal))
+                    intObj["maximum"] = maxVal
+            return intObj
         else:
             print("no base type found")
             sys.exit(2)
-    
+
     base_types = ['int8', 'int16', 'int32', 'int64',
                   'uint8', 'uint16', 'uint32', 'uint64',
                   'decimal64', 'string', 'boolean', 'enumeration',
                   'bits', 'binary', 'leafref', 'identityref', 'empty',
                   'union', 'instance-identifier'
-                ]
+                  ]
     # Get Type of a node
     t = node.search_one('type')
-    
+
+    if node.keyword == "type":
+        t = node
+
     while t.arg not in base_types:
         # chase typedef
         name = t.arg
@@ -1171,28 +1520,31 @@ def getType(node):
         else:
             # this is a prefixed name, check the imported modules
             err = []
-            pmodule = util.prefix_to_module(t.i_module,prefix,t.pos,err)
+            pmodule = util.prefix_to_module(t.i_module, prefix, t.pos, err)
             if pmodule is None:
                 return
             typedef = statements.search_typedef(pmodule, name)
-        
+
         if typedef is None:
-            print("Typedef ", name, " is not found, make sure all dependent modules are present")
+            print("Typedef ", name,
+                  " is not found, make sure all dependent modules are present")
             sys.exit(2)
-        t=typedef.search_one('type')
-    
-    return resolveType(t, t.arg)
+        t = typedef.search_one('type')
+
+    typeNodes.append(t)
+    return resolveType(t, t.arg, typeNodes)
 
 
 class Abort(Exception):
     """used to abort an iteration"""
     pass
 
+
 def isUriKeyInPayload(stmt, keyNodesList):
-    result = False # atleast one key is present
+    result = False  # atleast one key is present
 
     def checkFunc(node):
-        result = "continue"        
+        result = "continue"
         if node in keyNodesList:
             result = "stop"
         return result
@@ -1200,7 +1552,7 @@ def isUriKeyInPayload(stmt, keyNodesList):
     def _iterate(stmt):
         res = "continue"
         if stmt.keyword == "leaf" or \
-            stmt.keyword == "leaf-list":
+                stmt.keyword == "leaf-list":
             res = checkFunc(stmt)
         if res == 'stop':
             raise Abort
@@ -1214,5 +1566,78 @@ def isUriKeyInPayload(stmt, keyNodesList):
         _iterate(stmt)
     except Abort:
         result = True
-    
+
     return result
+
+
+def find_target_node(ctx, stmt, is_augment=False):
+    if (hasattr(stmt, 'is_grammatically_valid') and
+            stmt.is_grammatically_valid == False):
+        return None
+    if stmt.arg.startswith("/"):
+        is_absolute = True
+        arg = stmt.arg
+    else:
+        is_absolute = False
+        arg = "/" + stmt.arg  # to make node_id_part below work
+    # parse the path into a list of two-tuples of (prefix,identifier)
+    path = [(m[1], m[2]) for m in syntax.re_schema_node_id_part.findall(arg)]
+    # find the module of the first node in the path
+    (prefix, identifier) = path[0]
+    module = util.prefix_to_module(stmt.i_module, prefix, stmt.pos, ctx.errors)
+    if module is None:
+        # error is reported by prefix_to_module
+        return None
+
+    if (stmt.parent.keyword in ('module', 'submodule') or
+            is_absolute):
+        # find the first node
+        node = statements.search_child(
+            module.i_children, module.i_modulename, identifier)
+        if not statements.is_submodule_included(stmt, node):
+            node = None
+        if node is None:
+            err_add(ctx.errors, stmt.pos, 'NODE_NOT_FOUND',
+                    (module.i_modulename, identifier))
+            return None
+    else:
+        chs = [c for c in stmt.parent.parent.i_children
+               if hasattr(c, 'i_uses') and c.i_uses[0] == stmt.parent]
+        node = statements.search_child(chs, module.i_modulename, identifier)
+        if not statements.s_submodule_included(stmt, node):
+            node = None
+        if node is None:
+            err_add(ctx.errors, stmt.pos, 'NODE_NOT_FOUND',
+                    (module.i_modulename, identifier))
+            return None
+
+    # then recurse down the path
+    for (prefix, identifier) in path[1:]:
+        if hasattr(node, 'i_children'):
+            module = util.prefix_to_module(stmt.i_module, prefix, stmt.pos,
+                                           ctx.errors)
+            if module is None:
+                return None
+            child = statements.search_child(node.i_children, module.i_modulename,
+                                            identifier)
+            if child is None and module == stmt.i_module and is_augment:
+                # create a temporary statement
+                child = statements.Statement(node.top, node, stmt.pos, '__tmp_augment__',
+                                             identifier)
+                statements.v_init_stmt(ctx, child)
+                child.i_module = module
+                child.i_children = []
+                child.i_config = node.i_config
+                node.i_children.append(child)
+                # keep track of this temporary statement
+                stmt.i_module.i_undefined_augment_nodes[child] = child
+            elif child is None:
+                err_add(ctx.errors, stmt.pos, 'NODE_NOT_FOUND',
+                        (module.i_modulename, identifier))
+                return None
+            node = child
+        else:
+            err_add(ctx.errors, stmt.pos, 'NODE_NOT_FOUND',
+                    (module.i_modulename, identifier))
+            return None
+    return node

--- a/tools/restconf_doc_tools/index.py
+++ b/tools/restconf_doc_tools/index.py
@@ -1,0 +1,42 @@
+#! /usr/bin/env python3
+################################################################################
+#                                                                              #
+#  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
+#  its subsidiaries.                                                           #
+#                                                                              #
+#  Licensed under the Apache License, Version 2.0 (the "License");             #
+#  you may not use this file except in compliance with the License.            #
+#  You may obtain a copy of the License at                                     #
+#                                                                              #
+#     http://www.apache.org/licenses/LICENSE-2.0                               #
+#                                                                              #
+#  Unless required by applicable law or agreed to in writing, software         #
+#  distributed under the License is distributed on an "AS IS" BASIS,           #
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#  See the License for the specific language governing permissions and         #
+#  limitations under the License.                                              #
+#                                                                              #
+################################################################################
+import glob
+import argparse
+from jinja2 import Environment, FileSystemLoader
+import os
+import pdb
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--mdDir', dest='mdDir', help='OpenAPI docs directory')
+
+args = parser.parse_args()
+currentDir = os.path.dirname(os.path.realpath(__file__))
+# nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+templateEnv = Environment(loader=FileSystemLoader(currentDir),trim_blocks=True,lstrip_blocks=True)
+
+if args.mdDir and os.path.exists(args.mdDir):
+    files = glob.glob(args.mdDir+'/*.md')
+    files = list(map(lambda name: os.path.basename(name).split('.')[0], files))
+    template = templateEnv.get_template('index.template')
+    # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+    content = template.render(mdfiles=files)
+    with open(args.mdDir+"/index.md", "w") as fp:
+        fp.write(content)
+

--- a/tools/restconf_doc_tools/index.template
+++ b/tools/restconf_doc_tools/index.template
@@ -1,0 +1,186 @@
+# The SONiC RESTCONF APIs User Guide
+
+# Table of Contents
+  * [Introduction](#introduction)
+  * [Port and base URI](#port-and-base-uri)
+  * [Media Types](#media-types)
+  * [Authentication](#authentication)
+  * [YANG module discovery](#yang-module-discovery)
+  * [RESTCONF capabilities](#restconf-capabilities)
+  * [Authentication](#authentication)
+  * [Response codes and Error Messages](#response-codes-and-error-messages)
+  * [Limitations](#limitations)
+  * [Examples](#examples)
+  * [Supported RESTCONF APIs](#supported-restconf-apis)  
+  
+## Introduction
+
+The management REST Server on SONiC is based on the [RESTCONF](https://tools.ietf.org/html/rfc8040) protocol.
+RESTCONF uses HTTP methods to provide CRUD operations on a conceptual datastore containing YANG-defined data, which is compatible with a server that implements NETCONF datastores.
+For more details on [RESTCONF](https://tools.ietf.org/html/rfc8040) protocol, please refer [RESTCONF](https://tools.ietf.org/html/rfc8040) specification.
+
+## Port and base URI
+
+REST Server supports only HTTPS transport and listens on port 443. <br>
+Resources are represented with URIs following the structure for
+generic URIs in [RFC3986](https://tools.ietf.org/html/rfc3986).
+
+A RESTCONF operation is derived from the HTTP method and the request
+URI, using the following conceptual fields:
+
+    <OP> /<restconf>/<path>
+
+      ^       ^        ^      
+      |       |        |     
+    method  entry  resource 
+
+      M       M        O
+
+   M=mandatory, O=optional
+
+   where:
+
+     <OP> is the HTTP method
+     <restconf> is the RESTCONF root resource
+     <path> is the target resource URI
+
+### Method
+
+The HTTP method identifying the RESTCONF operation requested by the client, to act upon the target resource specified in the request URI.
+
+### Entry
+
+The root of the RESTCONF API configured on this HTTP server, discovered by getting the "/.well-known/host-meta" resource, as described in [RESTCONF Spec 3.1](https://tools.ietf.org/html/rfc8040#section-3.1).
+
+### Resource
+
+The path expression identifying the resource that is being accessed by the RESTCONF operation.
+
+## Media Types
+
+YANG defined RESTCONF APIs support **application/yang-data+json** media type. 
+Request and response payloads follow [RFC7951](https://tools.ietf.org/html/rfc7951) 
+defined encoding rules. Media type **application/yang-data+xml** is not supported
+in this release.
+
+## Authentication
+
+REST server will support below 3 authentication modes.
+
+* No authentication
+* TLS Certificate authentication
+* Username/password authentication
+
+Only one mode can be active at a time. 
+
+### No Authentication
+
+This is the default mode. REST server will not authenticate the client; all requests will be processed. It should not be used in production.
+
+### Certificate Authentication
+
+In this mode TLS public certificate of the client will be used to authenticate the client. Administrator will have to pre-provision the CA certificate. REST server will accept a request only if the client TLS certificate is signed by that CA.
+
+### User Authentication
+
+In this mode REST server expects the client to provide user credentials in every request. server will support HTTP Basic Authentication method to accept user credentials.
+
+REST write requests will be allowed only if the user belong to admin group. Only read operations will be allowed for other users.
+
+Performing TACACS+ authentication for every REST request can slow down the APIs. This will be optimized through JSON Web Token (JWT) or a similar mechanism in future release.
+
+
+## YANG module discovery
+
+REST server allows clients to discover and download all YANG modules supported by the server
+via "GET /restconf/data/ietf-yang-library:modules-state" API. Response data includes YANG module
+information as per [RFC7895](https://tools.ietf.org/html/rfc7895) requirements.
+
+REST server allows clients to download the YANG files via "GET /models/yang/{filename}" API.
+YANG module library response includes full download URL for every YANG module entry.
+
+Note - RFC7895 has been recently obsoleted by [RFC8525](https://tools.ietf.org/html/rfc8525).
+It supports YANG library with multi data stores and data store schemas. However these features
+are not available in SONiC. Hence REST server does not implement RFC8525 YANG library APIs (for now).
+
+## RESTCONF capabilities
+
+REST server supports "GET /restconf/data/ietf-restconf-monitoring:restconf-state/capabilities" API to
+advertise its capabilities as described in [RFC8040, section 9.1](https://tools.ietf.org/html/rfc8040#section-9.1).
+REsponse includes below mentioned capability information.
+
+    urn:ietf:params:restconf:capability:defaults:1.0?basic-mode=report-all
+
+## Response codes and Error Messages
+
+REST server sends back HTTP client error (4xx) or server error (5xx) status when request processing
+fails. Response status and payload will be as per RESTCONF specifications - [RCF8040, section7](https://tools.ietf.org/html/rfc8040#page-73).
+Error response data will be a JSON with below structure. Response Content-Type will be
+"application/yang-data+json".
+
+    +---- errors
+         +---- error*
+              +---- error-type       "protocol" or "application"
+              +---- error-tag        string
+              +---- error-app-tag?   string
+              +---- error-path?      xpath
+              +---- error-message?   string
+
+Note: REST server will not populate error-app-tag and error-path fields in this release. It can be
+enhanced in a future release. A sample error response:
+
+    {
+      "ietf-restconf:errors" : {
+        "error" : [
+          {
+            "error-type" : "application",
+            "error-tag" : "invalid-value",
+            "error-message" : "VLAN 100 not found"
+          }
+        ]
+      }
+    }
+
+**error-type** can be either "protocol" or "application", indicating the origin of the error.
+RESTCONF defines two more error-type enums "transport" and "rpc"; they are not used by REST server.
+
+**error-tag** indicates nature of error as described in [RFC8040, section 7](https://tools.ietf.org/html/rfc8040#page-74).
+
+**error-message** field carries a human friendly error message that can be displayed to the end
+user. This is an optional field; system error do not include error-message, or have generic
+messages like "Internal error".
+
+Table below lists possible error conditions with response status and data returned by REST server.
+
+Method  | Error condition          | Status | error-type  | error-tag        | error-message
+--------|--------------------------|--------|-------------|------------------|----------------------
+*any*   | Incorrect request data      | 400 | protocol    | invalid-value    |
+*write* | Bad content-type            | 415 | protocol    | invalid-value    | Unsupported content-type
+*write* | Schema validation fails    | 400 | protocol| invalid-value    | *YGOT returned message*
+*any*   | Invalid user credentials    | 401 | protocol    | access-denied    | Authentication failed
+*write* | User is not an admin        | 403 | protocol    | access-denied    | Authorization failed
+*write* | Commit failure     | 409 | protocol    | in-use           |
+*any*   | Unknown HTTP server failure | 500 | protocol    | operation-failed | Internal error
+*any*   | Not supported  | 405 | application | operation-not-supported | *App module returned message*
+*any*   | Incorrect payload           | 400 | application | invalid-value    | *App module returned message*
+*any*   | Resource not found          | 404 | application | invalid-value    | *App module returned message*
+POST    | Resource exists             | 409 | application | resource-denied  | *App module returned message*
+*any*   | Unknown error   | 500 | application | operation-failed | Internal error
+
+## Limitations
+
+* RESTCONF Notifications, streams are currently not supported
+* RESTCONF Query Parameters are currently not supported
+* RESTCONF entity tags and last modified timestamps are currently not supported
+
+## Examples
+
+Please refer [Appendix-B of RESTCONF Spec](https://tools.ietf.org/html/rfc8040#appendix-B) for the samples/examples.
+
+## Supported RESTCONF APIs
+
+Please click on the links below to explore RESTCONF APIs
+
+{% for file in mdfiles %}
+[{{file}}]({{file}}.md)
+{% endfor %}

--- a/tools/restconf_doc_tools/url_diff.py
+++ b/tools/restconf_doc_tools/url_diff.py
@@ -1,0 +1,374 @@
+#! /usr/bin/env python3
+################################################################################
+#                                                                              #
+#  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
+#  its subsidiaries.                                                           #
+#                                                                              #
+#  Licensed under the Apache License, Version 2.0 (the "License");             #
+#  you may not use this file except in compliance with the License.            #
+#  You may obtain a copy of the License at                                     #
+#                                                                              #
+#     http://www.apache.org/licenses/LICENSE-2.0                               #
+#                                                                              #
+#  Unless required by applicable law or agreed to in writing, software         #
+#  distributed under the License is distributed on an "AS IS" BASIS,           #
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#  See the License for the specific language governing permissions and         #
+#  limitations under the License.                                              #
+#                                                                              #
+################################################################################
+import glob
+import argparse
+import os, sys, io
+import json, pathlib
+from collections import OrderedDict
+import utils.json_delta as json_delta
+import pyang
+if pyang.__version__ > '2.4':
+    from pyang.repository import FileRepository
+    from pyang.context import Context
+else:
+    from pyang import FileRepository
+    from pyang import Context
+
+currentDir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(currentDir + '/../pyang/pyang_plugins/')
+import openapi
+
+ACTION_DICT = {
+    '+': 'URL_ADDED',
+    '-': 'URL_REMOVED',
+    ' ': 'URL_NO_CHANGE',
+    True: 'PAYLOAD_MODIFIED',
+    False: 'PAYLOAD_NO_CHANGE'
+}
+def mod_init(ctx, dict_store):
+    for entry in ctx.repository.modules:
+        mod_name = entry[0]
+        mod = entry[2][1]
+        if '/common/' not in mod:
+            try:
+                fd = io.open(mod, "r", encoding="utf-8")
+                text = fd.read()
+            except IOError as ex:
+                sys.stderr.write("error %s: %s\n" % (mod_name, str(ex)))
+                sys.exit(3)
+            mod_obj = ctx.add_module(mod_name, text)
+            if mod_name not in dict_store:
+                dict_store[mod_name] = mod_obj
+
+def generate_urls(ctx, mod_dict, mod_doc_dict):
+    for mod_name in mod_dict:
+        module = mod_dict[mod_name]
+        if module.keyword == "submodule":
+            continue
+        openapi.currentTag = module.i_modulename
+        openapi.globalCtx = ctx
+        openapi.globalCtx.opts = args
+        openapi.resetSwaggerDict()
+        openapi.resetDocJson()
+        openapi.walk_module(module)
+        doc_config = openapi.docJson["config"]
+        if "/restconf/data/" in doc_config:
+            del(doc_config["/restconf/data/"])
+        doc_operstate = openapi.docJson["operstate"]
+        if "/restconf/data/" in doc_operstate:
+            del(doc_operstate["/restconf/data/"])
+        doc_operations = openapi.docJson["operations"]
+        if "/restconf/data/" in doc_operations:
+            del(doc_operations["/restconf/data/"])
+
+        if len(doc_config) > 0 or len(doc_operstate) > 0 or len(doc_operations) > 0:
+            if mod_name not in mod_doc_dict:
+                mod_doc_dict[mod_name] = OrderedDict()            
+            mod_doc_dict[mod_name]["config"] = doc_config
+            mod_doc_dict[mod_name]["state"] = doc_operstate
+            mod_doc_dict[mod_name]["operations"] = doc_operations
+
+def write_payload(writer, lines, method, reqPrefix="Request"):
+    writer.write(
+        "\n<details>\n<summary>%s payload for %s</summary>\n<p>" % (reqPrefix, method.upper()))
+    writer.write("\n\n```json\n")
+    writer.write(lines)
+    writer.write("\n```\n")
+    writer.write("</p>\n</details>\n\n")
+
+def sorting(item):
+    if isinstance(item, dict):
+        return sorted((key, sorting(values)) for key, values in item.items())
+    if isinstance(item, list):
+        return sorted(sorting(x) for x in item)
+    else:
+        return item
+        
+def dump_payload_diff(stat_dict, payload_writer, source_dict, target_dict, mode, url, action, unified):
+    payload_differs = False
+    writer = io.StringIO()
+    if action == '+':
+        for method in ['put', 'post', 'patch', 'get', 'input', 'output']:
+            if method == 'get' or method == 'output':
+                prefix = 'Response'
+            else:
+                prefix = 'Request'
+            if method in source_dict[mode][url]:
+                left = {}
+                if method == 'input' or method == 'output':
+                    right_body = source_dict[mode][url][method]
+                else:
+                    right_body = source_dict[mode][url][method]['body']
+                right = json.loads(json.dumps(right_body))
+                if sorting(left) != sorting(right):
+                    payload_differs = True
+                    stat_dict["payload_modified"] = stat_dict["payload_modified"] + 1
+                    diff_lines = '\n'.join(list(json_delta._udiff.udiff(left, right, indent=2, use_ellipses=False))[1:])
+                    write_payload(writer, diff_lines, method, prefix)
+    elif action == '-':
+        for method in ['put', 'post', 'patch', 'get', 'input', 'output']:
+            if method == 'get' or method == 'output':
+                prefix = 'Response'
+            else:
+                prefix = 'Request'
+            if method in target_dict[mode][url]:
+                if method == 'input' or method == 'output':
+                    left_body = target_dict[mode][url][method]
+                else:
+                    left_body = target_dict[mode][url][method]['body']
+                left = json.loads(json.dumps(left_body))
+                right = {}
+                if sorting(left) != sorting(right):
+                    payload_differs = True
+                    stat_dict["payload_modified"] = stat_dict["payload_modified"] + 1
+                    diff_lines = '\n'.join(list(json_delta._udiff.udiff(left, right, indent=2, use_ellipses=False))[:-1])
+                    write_payload(writer, diff_lines, method, prefix)
+    else:
+        for method in ['put', 'post', 'patch', 'get', 'input', 'output']:
+            if method == 'get' or method == 'output':
+                prefix = 'Response'
+            else:
+                prefix = 'Request'
+            if method in source_dict[mode][url] and method in target_dict[mode][url]:
+                if method == 'input' or method == 'output':
+                    right_body = target_dict[mode][url][method]
+                else:
+                    right_body = target_dict[mode][url][method]['body']
+                if method == 'input' or method == 'output':
+                    left_body = source_dict[mode][url][method]
+                else:
+                    left_body = source_dict[mode][url][method]['body']
+                right = json.loads(json.dumps(right_body))
+                left = json.loads(json.dumps(left_body))
+                if sorting(left) != sorting(right):
+                    payload_differs = True
+                    stat_dict["payload_modified"] = stat_dict["payload_modified"] + 1
+                    diff_lines = '\n'.join(json_delta._udiff.udiff(left, right, indent=2, use_ellipses=False))
+                    write_payload(writer, diff_lines, method, prefix)
+    
+    if payload_differs or unified:
+        payload = writer.getvalue()
+        if len(payload) > 0:
+            payload_writer.write('\n### {}\n'.format(url))
+            payload_writer.write(payload)
+    return payload_differs
+
+def dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, mode, unified=False):
+    added_urls = set(source_dict[mode].keys()) - set(target_dict[mode].keys())
+    removed_urls = set(target_dict[mode].keys()) - set(source_dict[mode].keys())
+    stat_dict["added"] = stat_dict["added"] + len(added_urls)
+    stat_dict["removed"] = stat_dict["removed"] + len(removed_urls)
+    action = None
+    change_detected = False
+    for url in set(source_dict[mode].keys()) | set(target_dict[mode].keys()):
+        if url in added_urls:
+            action = '+'
+        elif url in removed_urls:
+            action = '-'
+        else:
+            action = ' '
+        payload_differs = dump_payload_diff(stat_dict, payload_writer, source_dict, target_dict, mode, url, action, unified)
+        if not unified:
+            if url in added_urls or url in removed_urls or payload_differs:
+                if args.with_payload:
+                    writer.write("| %s | %s [%s](###-%s) |\n" % (url, ACTION_DICT[action], ACTION_DICT[payload_differs], url))
+                else:
+                    writer.write("| %s | %s %s |\n" % (url, ACTION_DICT[action], ACTION_DICT[payload_differs]))
+                change_detected = True
+        else:
+            writer.write("| %s | %s [%s](###-%s) |\n" % (url, ACTION_DICT[action], ACTION_DICT[payload_differs], url))
+            change_detected = True
+    return change_detected
+
+def dump_url_from_single_source(stat_dict, writer, payload_writer,  data_dict, data_dict_ext, mode, action):    
+    for url in data_dict:
+        if args.with_payload:
+            writer.write("| %s | %s [%s](###-%s) |\n" % (url, ACTION_DICT[action], ACTION_DICT[True], url))
+        else:
+            writer.write("| %s | %s %s |\n" % (url, ACTION_DICT[action], ACTION_DICT[True]))
+        if action == '+':
+            stat_dict["added"] = stat_dict["added"] + 1
+            dump_payload_diff(stat_dict, payload_writer, data_dict_ext, None, mode, url, action, True)
+        elif action == '-':
+            stat_dict["removed"] = stat_dict["removed"] + 1
+            dump_payload_diff(stat_dict, payload_writer, None, data_dict_ext, mode, url, action, True)
+        else:
+            pass # should never come here
+
+def write_urls(stat_dict, writer, source_dict, target_dict=None, unified=False):
+    payload_writer = io.StringIO()
+    change_detected = False
+    if target_dict is None:
+        dump_url_from_single_source(stat_dict, writer, payload_writer,  source_dict['config'].keys(), source_dict, 'config', '+',)
+        dump_url_from_single_source(stat_dict, writer, payload_writer,  source_dict['state'].keys(), source_dict, 'state', '+')
+        dump_url_from_single_source(stat_dict, writer, payload_writer,  source_dict['operations'].keys(), source_dict, 'operations', '+')
+        change_detected = True
+    elif source_dict is None:
+        dump_url_from_single_source(stat_dict, writer, payload_writer,  target_dict['config'].keys(), target_dict, 'config', '-')
+        dump_url_from_single_source(stat_dict, writer, payload_writer,  target_dict['state'].keys(), target_dict, 'state', '-')
+        dump_url_from_single_source(stat_dict, writer, payload_writer,  target_dict['operations'].keys(), target_dict, 'operations', '-')
+        change_detected = True
+    else:
+        if args.unified:
+            _ = dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, 'config', True)
+            _ = dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, 'state', True)
+            _ = dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, 'operations', True)
+            change_detected = True
+        else:
+            change_detected_config = dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, 'config')
+            change_detected_state = dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, 'state')
+            change_detected_operations = dump_diff_url(stat_dict, writer, payload_writer, source_dict, target_dict, 'operations')
+            if change_detected_config or change_detected_state or change_detected_operations:
+                change_detected = True
+    
+    if args.with_payload:
+        writer.write("\n## Below section contains payload diffs for URLs\n")
+        writer.write(payload_writer.getvalue())
+        payload_writer.close()
+    
+    return change_detected
+
+def process(args):
+    """
+    1. Validates args
+    2. Build YANG model
+    3. Generates docs
+    """
+    sourcedir = pathlib.Path('/NOT_EXISTS')
+    targetdir = pathlib.Path('/NOT_EXISTS')
+    if hasattr(args, 'targetdir') and hasattr(args, 'sourcedir'):
+        sourcedir = args.sourcedir
+        targetdir = args.targetdir
+    elif hasattr(args, 'targetrepo') and hasattr(args, 'sourcerepo'):
+        sourcedir = args.sourcerepo.joinpath('build/yang')
+        targetdir = args.targetrepo.joinpath('build/yang')
+    else:
+        pass # should never come here
+
+    # check if paths are valid
+    if not sourcedir.exists():
+        print("source_dir: {} does not exists".format(sourcedir._str))
+        sys.exit(2)
+    if not targetdir.exists():
+        print("target_dir: {} does not exists".format(targetdir._str))
+        sys.exit(2)
+    if not args.shell and not args.outdir.exists():
+        print("outdir: {} does not exists".format(args.outdir._str))
+        sys.exit(2)
+    
+    # Init Repo
+    sourcedir = sourcedir._str
+    targetdir = targetdir._str
+
+    source_path = sourcedir+'/:/'+sourcedir+'/common:/'+sourcedir+'/extensions'
+    target_path = targetdir+'/:/'+targetdir+'/common:/'+targetdir+'/extensions'
+    source_repo = FileRepository(source_path, use_env=False)
+    source_ctx = Context(source_repo)
+    target_repo = FileRepository(target_path, use_env=False)
+    target_ctx = Context(target_repo)
+    source_mod_dict = OrderedDict()
+    target_mod_dict = OrderedDict()
+    
+    # Init Modules
+    print("Processing Source YANGs...")
+    mod_init(source_ctx, source_mod_dict)
+    print("Processing Target YANGs...")
+    mod_init(target_ctx, target_mod_dict)
+    print("Validating Source YANGs...")
+    source_ctx.validate()
+    print("Validating Target YANGs...")
+    target_ctx.validate()
+
+    # Generate URLs
+    source_doc_dict = OrderedDict()
+    target_doc_dict = OrderedDict()
+    print("Generating Source YANG's URLs...")
+    generate_urls(source_ctx, source_mod_dict, source_doc_dict)
+    print("Generating Target YANG's URLs...")
+    generate_urls(target_ctx, target_mod_dict, target_doc_dict)
+    print("Generating Diff Docs...")
+
+    if args.shell:
+        print("Command-line feature is not yet supported. Thank You!!")
+        sys.exit(0)
+    else:
+        fp_dict = OrderedDict()
+        stat_dict = OrderedDict()
+        mod_status_dict = OrderedDict()
+        for mod in set(source_doc_dict.keys()) | set(target_doc_dict.keys()):
+            fp_dict[mod] = io.StringIO()
+            stat_dict[mod] = {"added":0, "removed":0, "payload_modified":0}
+            mod_status_dict[mod] = False
+            fp_dict[mod].write('| URL | Action |\n')
+            fp_dict[mod].write('| --- | --- |\n')
+        
+        for mod in set(source_doc_dict.keys()) - set(target_doc_dict.keys()):        
+            mod_status = write_urls(stat_dict[mod], fp_dict[mod], source_doc_dict[mod])
+            if not mod_status_dict[mod]:
+                mod_status_dict[mod] = mod_status
+
+        for mod in set(target_doc_dict.keys()) - set(source_doc_dict.keys()):    
+            mod_status = write_urls(stat_dict[mod], fp_dict[mod], target_doc_dict[mod])
+            if not mod_status_dict[mod]:
+                mod_status_dict[mod] = mod_status
+        
+        for mod in set(source_doc_dict.keys()) & set(target_doc_dict.keys()):
+            mod_status= write_urls(stat_dict[mod], fp_dict[mod], source_doc_dict[mod], target_doc_dict[mod],args)
+            if not mod_status_dict[mod]:
+                mod_status_dict[mod] = mod_status
+
+        for mod in fp_dict:
+            if mod_status_dict[mod]:
+                print("Writing Diff Doc for {}...".format(mod))
+                stat_writer = io.StringIO()
+                stat_writer.write("# {} - RESTCONF URL Diff Document\n\n".format(mod))
+                stat_writer.write('| URLs Added | URLs Removed | Payload modified\n')
+                stat_writer.write('| --- | --- | --- |\n')
+                stat_writer.write("| {} | {} | {}\n".format(stat_dict[mod]["added"], stat_dict[mod]["removed"], stat_dict[mod]["payload_modified"]))
+                content = stat_writer.getvalue() + "\n" + fp_dict[mod].getvalue()
+                with open("{}/{}.md".format(args.outdir, mod), "w") as fp:
+                    fp.write(content)
+                fp_dict[mod].close()
+            else:
+                print("No change in {}, Diff doc is not required...".format(mod))
+        print("Access URL Diff Docs at {}.\nPlease use editor with markdown support(example: Github editor) for better readability.".format(args.outdir))
+
+if __name__== "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(help='help for source/target locations')
+    
+    # create the parser for the "reading yangs from repo"
+    repo_parser = subparsers.add_parser('repo', help='Specify source/target repos (type repo -h for help. Supported only for SONiC >= 4.0.0')
+    repo_parser.add_argument('--sourceRepo', dest='sourcerepo', help='Source sonic-mgmt-common directory', required=True, type=pathlib.Path)
+    repo_parser.add_argument('--targetRepo', dest='targetrepo', help='Target sonic-mgmt-common directory', required=True, type=pathlib.Path)
+
+    # create the parser for the "reading yangs from directory"
+    dir_parser = subparsers.add_parser('dir', help='Specify source/target yang directory (type dir -h for help')
+    dir_parser.add_argument('--sourceDir', dest='sourcedir', help='Source yangs directory', required=True, type=pathlib.Path)
+    dir_parser.add_argument('--targetDir', dest='targetdir', help='Target yangs directory', required=True, type=pathlib.Path)
+
+    parser.add_argument('--unified', dest='unified', action='store_true', help='Prints All URLs, otherwise only Diff Urls are printed')
+    parser.add_argument('--shell', dest='shell', action='store_true', help='Starts a command-line interface')
+    parser.add_argument('--outdir', dest='outdir', help='The output directory to dump the diff docs', required=True, type=pathlib.Path)
+    parser.add_argument('--no_oneof', dest='no_oneof')
+    parser.add_argument('--with_payload', dest='with_payload', action='store_true', help='Default:False')
+    args = parser.parse_args()
+    process(args)
+

--- a/tools/restconf_doc_tools/utils/json_delta/LICENSE
+++ b/tools/restconf_doc_tools/utils/json_delta/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2012-2020 Philip J. Roberts
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/tools/restconf_doc_tools/utils/json_delta/README.md
+++ b/tools/restconf_doc_tools/utils/json_delta/README.md
@@ -1,0 +1,16 @@
+
+Credits to Philip J. Roberts(himself@phil-roberts.name)
+
+JSON Delta(json_delta) has been taken from below link
+https://files.pythonhosted.org/packages/aa/b6/cdc4ccf3923651cb42797b4c703b77a626014f3ebe3fdee7858a38e0a82e/json_delta-2.0.2.tar.gz
+
+Open-source base Version: 2.0.2
+
+Change log:
+
+Date|Author|Description|
+----|------|-----------|
+25-JUNE-2021 | Mohammed Faraaz C | Fixed invalid JSON rendering, when output format is udiff.
+
+
+

--- a/tools/restconf_doc_tools/utils/json_delta/__init__.py
+++ b/tools/restconf_doc_tools/utils/json_delta/__init__.py
@@ -1,0 +1,238 @@
+# -*- encoding: utf-8 -*-
+# json_delta: a library for computing deltas between JSON-serializable
+# structures.
+# json_delta/__init__.py
+#
+# Copyright 2012‒2020 Philip J. Roberts <himself@phil-roberts.name>.
+# BSD License applies; see the LICENSE file, or
+# http://opensource.org/licenses/BSD-2-Clause
+'''This is the main “library” for json_delta’s functionality.  Functions
+available within the namespace of this module are to be considered
+part of json_delta’s stable API, subject to change only after a lot
+of noisy announcements and gnashing of teeth.
+
+The names of submodules begin with underscores because the same is not
+true of them: the functionality behind the main entry points
+:func:`diff`, :func:`patch`, :func:`udiff`, :func:`upatch` may be
+refactored at any time.
+
+Requires Python 2.7 or newer (including Python 3).
+
+'''
+from __future__ import print_function, unicode_literals
+import sys
+
+__VERSION__ = '2.0.2'
+
+from ._diff import diff as _diff_func
+from ._patch import patch
+from ._udiff import udiff
+from ._upatch import upatch
+
+from ._util import _load_and_func
+
+
+def diff(left_struc, right_struc, minimal=None, verbose=True, key=None,
+         array_align=True, compare_lengths=True, common_key_threshold=0.0):
+    '''Compose a sequence of diff stanzas sufficient to convert the
+    structure ``left_struc`` into the structure ``right_struc``.  (The
+    goal is to add 'necessary and' to 'sufficient' above!).
+
+    Optional parameters:
+        ``verbose``: Print compression statistics to
+        stderr, and warn if the setting of ``minimal`` contradicts the
+        other parms.
+
+        ``array_align``: Use :py:func:`_diff.needle_diff` to compute
+        deltas between arrays.  Relatively computationally expensive,
+        but likely to produce shorter diffs.  Defaults to ``True``.
+
+        ``compare_lengths``: If ``[[key, right_struc]]`` can be
+        encoded as a shorter JSON-string, return it instead of
+        examining the internal structure of ``left_struc`` and
+        ``right_struc``.  It involves calling :py:func:`json.dumps`
+        twice for every node in the structure, but may result in
+        smaller diffs.  Defaults to ``True``.
+
+        ``common_key_threshold``: Skip recursion into ``left_struc`` and
+        ``right_struc`` if the fraction of keys they have in common
+        (with the same value) is less than this parm (which should be a
+        float between ``0.0`` and ``1.0``).  Defaults to 0.0.
+
+        ``minimal``: Included for backwards compatibility.  ``True`` is
+        equivalent to ``(array_align=True, compare_lengths=True,
+        common_key_threshold=0.0)``; ``False`` is equivalent to
+        ``(array_align=False, compare_lengths=False,
+        common_key_threshold=0.5)``.  Specific settings of
+        ``array_align``, ``compare_lengths`` or ``common_key_threshold``
+        will supersede this parm, warning on stderr if ``verbose`` and
+        ``minimal`` are both set.
+
+        ``key``: Also included for backwards compatibility.  If set,
+        will be prepended to the key in each stanza of the output.
+
+    The parameter ``key`` is present because this function is mutually
+    recursive with :func:`_diff.needle_diff` and :func:`_diff.keyset_diff`.
+    If set to a list, it will be prefixed to every keypath in the
+    output.
+
+    '''
+    return _diff_func(left_struc, right_struc, verbose=verbose, key=key,
+                      **_check_diff_parms(vars()))
+
+
+def _check_diff_parms(parms):
+    '''Resolve parameters to :py:func:`diff`
+
+    Output is a dict suitable for ``**`` passing to :func:`_diff.diff`.
+
+    '''
+    options = {k: parms[k] for k in ('array_align', 'compare_lengths',
+                                     'common_key_threshold')
+               if parms[k] is not None}
+    if parms['minimal'] is None:
+        return options
+
+    if parms['minimal']:
+        defaults = {'array_align': True, 'compare_lengths': True,
+                    'common_key_threshold': 0.0}
+    else:
+        defaults = {'array_align': False, 'compare_lengths': False,
+                    'common_key_threshold': 0.5}
+
+    if ((not set(defaults.items()).issuperset(options.items()))
+        and parms['verbose']):
+        defaults.update(options)
+        print('''Warning: arguments contradict one another!  Using the following parms:
+\tarray_align: {array_align}
+\tcompare_lengths: {compare_lengths}
+\tcommon_key_threshold: {common_key_threshold}'''.format(**defaults),
+              file=sys.stderr)
+    else:
+        defaults.update(options)
+    return defaults
+
+
+def load_and_diff(left=None, right=None, both=None, array_align=None,
+                  compare_lengths=None, common_key_threshold=None,
+                  minimal=None, verbose=True):
+    '''Apply :py:func:`diff` to strings or files representing
+    JSON-serialized structures.
+
+    Specify either ``left`` and ``right``, or ``both``, like so:
+
+    >>> (load_and_diff('{"foo":"bar"}', '{"foo":"baz"}', verbose=False)
+    ...  == [[["foo"],"baz"]])
+    True
+    >>> (load_and_diff(both='[{"foo":"bar"},{"foo":"baz"}]', verbose=False)
+    ...  == [[["foo"],"baz"]])
+    True
+
+    ``left``, ``right`` and ``both`` may be either strings (instances
+    of `basestring` in 2.7) or file-like objects.
+
+    ``minimal`` and ``verbose`` are passed through to :py:func:`diff`,
+    which see.
+
+    A call to this function with string arguments is strictly
+    equivalent to calling ``diff(json.loads(left), json.loads(right),
+    minimal=minimal, verbose=verbose)`` or ``diff(*json.loads(both),
+    minimal=minimal, verbose=verbose)``, as appropriate.
+    '''
+    return _load_and_func(diff, left, right, both,
+                          array_align=array_align,
+                          compare_lengths=compare_lengths,
+                          common_key_threshold=common_key_threshold,
+                          minimal=minimal, verbose=verbose)
+
+
+def load_and_patch(struc=None, stanzas=None, both=None):
+    '''Apply :py:func:`patch` to strings or files representing
+    JSON-serialized structures.
+
+    Specify either ``struc`` and ``stanzas``, or ``both``, like so:
+
+    >>> (load_and_patch('{"foo":"bar"}', '[[["foo"],"baz"]]') ==
+    ...  {"foo": "baz"})
+    True
+    >>> (load_and_patch(both='[{"foo":"bar"},[[["foo"],"baz"]]]') ==
+    ...  {"foo": "baz"})
+    True
+
+    ``struc``, ``stanzas`` and ``both`` may be either strings (instances
+    of `basestring` in 2.7) or file-like objects.
+
+    A call to this function with string arguments is strictly
+    equivalent to calling ``patch(json.loads(struc), json.loads(stanzas),
+    in_place=in_place)`` or ``patch(*json.loads(both),
+    in_place=in_place)``, as appropriate.
+    '''
+    return _load_and_func(patch, struc, stanzas, both)
+
+
+def load_and_udiff(left=None, right=None, both=None,
+                   stanzas=None, indent=0):
+    '''Apply :py:func:`udiff` to strings representing JSON-serialized
+    structures.
+
+    Specify either ``left`` and ``right``, or ``both``, like so:
+
+    >>> udiff = """ {
+    ...  "foo":
+    ... -  "bar"
+    ... +  "baz"
+    ...  }"""
+    >>> test = load_and_udiff('{"foo":"bar"}', '{"foo":"baz"}')
+    >>> '\\n'.join(test) == udiff
+    True
+    >>> test = load_and_udiff(both='[{"foo":"bar"},{"foo":"baz"}]')
+    >>> '\\n'.join(test) == udiff
+    True
+
+    ``left``, ``right`` and ``both`` may be either strings (instances
+    of `basestring` in 2.7) or file-like objects.
+
+    ``stanzas`` and ``indent`` are passed through to :py:func:`udiff`,
+    which see.
+
+    A call to this function with string arguments is strictly
+    equivalent to calling ``udiff(json.loads(left), json.loads(right),
+    stanzas=stanzas, indent=indent)`` or ``udiff(*json.loads(both),
+    stanzas=stanzas, indent=indent)``, as appropriate.
+    '''
+    return _load_and_func(udiff, left, right, both,
+                          patch=stanzas, indent=indent)
+
+
+def load_and_upatch(struc=None, json_udiff=None, both=None,
+                    reverse=False):
+    """Apply :py:func:`upatch` to strings representing JSON-serialized
+    structures.
+
+    Specify either ``struc`` and ``json_udiff``, or ``both``, like so:
+
+    >>> struc = '{"foo":"bar"}'
+    >>> json_udiff = r'" {\\n  \\"foo\\":\\n-  \\"bar\\"\\n+  \\"baz\\"\\n }"'
+    >>> both = r'[{"foo":"baz"}," '\\
+    ... r'{\\n  \\"foo\\":\\n-  \\"bar\\"\\n+  \\"baz\\"\\n }"]'
+    >>> load_and_upatch(struc, json_udiff) == {"foo": "baz"}
+    True
+    >>> load_and_upatch(both=both, reverse=True) == {"foo": "bar"}
+    True
+
+    ``struc``, ``json_udiff`` and ``both`` may be either strings
+    (instances of `basestring` in 2.7) or file-like objects.  Note
+    that ``json_udiff`` is so named because it must be a
+    JSON-serialized representation of the udiff string, not the udiff
+    string itself.
+
+    ``reverse`` is passed through to :py:func:`upatch`, which see.
+
+    A call to this function with string arguments is strictly
+    equivalent to calling ``upatch(json.loads(struc),
+    json.loads(json_udiff), reverse=reverse, in_place=in_place)`` or
+    ``upatch(*json.loads(both), reverse=reverse, in_place=in_place)``,
+    as appropriate.
+
+    """
+    return _load_and_func(upatch, struc, json_udiff, both, reverse=reverse)

--- a/tools/restconf_doc_tools/utils/json_delta/_diff.py
+++ b/tools/restconf_doc_tools/utils/json_delta/_diff.py
@@ -1,0 +1,488 @@
+# -*- encoding: utf-8 -*-
+# json_delta: a library for computing deltas between JSON-serializable
+# structures.
+# json_delta/_diff.py
+#
+# Copyright 2012‒2020 Philip J. Roberts <himself@phil-roberts.name>.
+# BSD License applies; see the LICENSE file, or
+# http://opensource.org/licenses/BSD-2-Clause
+'''Functions for computing JSON-format diffs.'''
+
+from __future__ import print_function, unicode_literals
+from ._util import TERMINALS, NONTERMINALS
+from ._util import struc_lengths, keypath_lengths, json_length, all_paths
+from ._util import in_array, in_object, range, whitespace_count
+
+import copy
+import bisect
+import sys
+
+
+def diff(left_struc, right_struc,
+         array_align=True, compare_lengths=True, common_key_threshold=0.0,
+         verbose=True, key=None):
+    '''Compose a sequence of diff stanzas sufficient to convert the
+    structure ``left_struc`` into the structure ``right_struc``.
+    (Whether you can add ‘necessary and’ to ‘sufficient to’ depends on
+    the setting of the other parms, and how many cycles you want to
+    burn; see below).
+
+    Optional parameters:
+        ``array_align``: Use :py:func:`needle_diff` to compute deltas
+        between arrays.  Computationally expensive, but likely to
+        produce shorter diffs.  If this parm is set to the string
+        ``'udiff'``, :py:func:`needle_diff` will optimize for the
+        shortest udiff, instead of the shortest JSON-format diff.
+        Otherwise, set to any value that is true in a Boolean context
+        to enable.
+
+        ``compare_lengths``: If at any level ``[[key, right_struc]]``
+        can be encoded as a shorter JSON-string, return it instead of
+        examining the internal structure of ``left_struc`` and
+        ``right_struc``.  May result in smaller diffs.
+
+        ``common_key_threshold``: Skip recursion into ``left_struc``
+        and ``right_struc`` if the fraction of keys they have in
+        common (as computed by :func:`commonality`, which see) is less
+        than this parm (which should be a float between ``0.0`` and
+        ``1.0``).
+
+        ``verbose``: Print compression statistics to stderr.
+
+    The parameter ``key`` is present because this function is mutually
+    recursive with :py:func:`needle_diff` and :py:func:`keyset_diff`.
+    If set to a list, it will be prefixed to every keypath in the
+    output.
+
+    '''
+    if key is None:
+        key = []
+
+    options = {'common_key_threshold': common_key_threshold,
+               'array_align': array_align,
+               'compare_lengths': compare_lengths}
+
+    if array_align or compare_lengths:
+        val_lengths, obj_lengths = struc_lengths(right_struc)
+        key_lengths = keypath_lengths([tuple(p)
+                                       for p in all_paths(right_struc)])
+        val_lengths['i'] = 3
+
+        if array_align == 'udiff':
+            u = struc_lengths(left_struc)
+            val_lengths.update(u[0])
+            obj_lengths.update(u[1])
+            pad_val_lengths = {k: v + whitespace_count(v)
+                               for k, v in val_lengths.items()}
+            pad_obj_lengths = {k: v + whitespace_count(v)
+                               for k, v in obj_lengths.items()}
+            pad_key_lengths = {k: v + whitespace_count(v)
+                               for k, v in key_lengths.items()}
+    else:
+        key_lengths = val_lengths = obj_lengths = {}
+
+    def key_length(keypath):
+        keypath = tuple(keypath)
+        if keypath not in key_lengths:
+            key_lengths[keypath] = json_length(keypath)
+        return key_lengths[keypath]
+
+    def pad_key_length(keypath):
+        keypath = tuple(keypath)
+        if keypath not in pad_key_lengths:
+            pad_key_lengths[keypath] = (key_length(keypath)
+                                        + whitespace_count(keypath))
+        return pad_key_lengths[keypath]
+
+    def stanza_length(stanza):
+        length = 2  # '[]'
+        length += key_length(stanza[0])
+        for part in stanza[1:]:
+            length += 1  # ','
+            if id(part) in obj_lengths:
+                length += obj_lengths[id(part)]
+            else:
+                length += val_lengths[part]
+        return length
+
+    def diff_length(diff):
+        if not diff:
+            return 2  # '[]
+        length = 1  # '[
+        for stanza in diff:
+            length += stanza_length(stanza)
+            length += 1  # ',' or ']'
+        return length
+
+    def sub_diff(left_struc, right_struc, key):
+        common = (0.0 if common_key_threshold == 0.0 else
+                  commonality(left_struc, right_struc))
+        if (common < common_key_threshold
+            or not structure_comparable(left_struc, right_struc)):
+            my_diff = this_level_diff(left_struc, right_struc, key, common)
+        elif array_align:
+            my_diff = needle_diff(left_struc, right_struc, key)
+        else:
+            my_diff = keyset_diff(left_struc, right_struc, key)
+
+        if (compare_lengths and
+            (diff_length([[key[:], right_struc]]) <
+             diff_length(my_diff))):
+            c = copy.copy(right_struc)
+            obj_lengths[id(c)] = obj_lengths[id(right_struc)]
+            my_diff = [[key[:], c]]
+        return sort_stanzas(my_diff)
+
+    def needle_diff(left_struc, right_struc, key):
+        '''Returns a diff between ``left_struc`` and ``right_struc``.
+
+        If ``left_struc`` and ``right_struc`` are both serializable as
+        arrays, this function will use a Needleman-Wunsch sequence
+        alignment to find a minimal diff between them.  Otherwise, the
+        inputs are passed on to :func:`keyset_diff`.
+
+        '''
+        if type(left_struc) not in (list, tuple):
+            return keyset_diff(left_struc, right_struc, key)
+        assert type(right_struc) in (list, tuple)
+
+        down_col = 0
+        lastrow = [
+            [[key + [sub_i]] for sub_i in range(i)]
+            for i in range(len(left_struc), -1, -1)
+        ]
+
+        def modify_cand():
+            '''Build the candidate diff that involves (potentially) modifying an
+            element.'''
+            if col_i + 1 < len(lastrow):
+                basis = lastrow[col_i + 1]
+                mutand_key = key + [left_i]
+                return (basis + sub_diff(left_elem, right_elem,
+                                         key=mutand_key))
+
+        def delete_cand():
+            '''Build the candidate diff that involves deleting an element.'''
+            if row:
+                basis = row[0]
+                delend_key = key + [left_i]
+                return (basis + [[delend_key]])
+
+        def append_cand():
+            '''Build the candidate diff that involves appending an element.'''
+            if col_i == down_col:
+                basis = lastrow[col_i]
+                append_at_key = key + [append_key(lastrow[col_i],
+                                                  left_struc, key)]
+                return (basis + [[append_at_key, right_elem]])
+
+        def insert_cand():
+            '''Build the candidate diff that involves an insert-and-shift.'''
+            if col_i != down_col:
+                basis = lastrow[col_i]
+                insertion_key = key + [right_i]
+                return (basis + [[insertion_key, right_elem, 'i']])
+
+        def estimate_udiff_length(diff):
+            '''Estimate the length of a udiff based on ``diff``.'''
+            out = 0
+            for stanza in diff:
+                try:
+                    subkey = stanza[0][len(key):]
+                    out += pad_key_length(subkey)
+                except (KeyError, IndexError):
+                    pass
+                if len(stanza) > 1:
+                    assert 2 <= len(stanza) <= 3, stanza
+                    obj = stanza[1]
+                    if isinstance(obj, TERMINALS):
+                        out += pad_val_lengths[obj]
+                    else:
+                        assert isinstance(obj, NONTERMINALS), obj
+                        out += pad_obj_lengths[id(obj)]
+            return out
+
+        for right_i, right_elem in enumerate(right_struc):
+            col_i = len(left_struc)
+            row = [insert_cand()]
+
+            for left_i, left_elem in enumerate(left_struc):
+                col_i = len(left_struc) - left_i - 1
+                cands = (c for c in (modify_cand(), delete_cand(),
+                                     append_cand(), insert_cand())
+                         if c is not None)
+                if options['array_align'] == 'udiff':
+                    winner = min(cands, key=estimate_udiff_length)
+                else:
+                    winner = min(cands, key=diff_length)
+                row.insert(0, winner)
+
+            lastrow = row
+        return winner
+
+    def keyset_diff(left_struc, right_struc, key):
+        '''Return a diff between ``left_struc`` and ``right_struc``.
+
+        It is assumed that ``left_struc`` and ``right_struc`` are both
+        non-terminal types (serializable as arrays or objects).
+        Sequences are treated just like mappings by this function, so
+        the diffs will be correct but not necessarily minimal.  For a
+        minimal diff between two sequences, use :func:`needle_diff`.
+
+        '''
+        out = []
+        (overlap, left_only, right_only) = compute_keysets(left_struc,
+                                                           right_struc)
+        out.extend([[key + [k]] for k in left_only])
+        out.extend([[key + [k], right_struc[k]] for k in right_only])
+        for k in overlap:
+            sub_key = key + [k]
+            out.extend(sub_diff(left_struc[k], right_struc[k], key=sub_key))
+        return out
+
+    my_diff = sub_diff(left_struc, right_struc, key)
+    if verbose:
+        msg = ('Size of delta {:.3f}% size of original '
+               '(original: {} chars, delta: {} chars)')
+        print(msg.format(*compute_diff_stats(right_struc, my_diff, True),
+              file=sys.stderr))
+    return my_diff
+
+
+def compute_diff_stats(target, diff, percent=True):
+    '''Calculate the size of a minimal JSON dump of ``target`` and ``diff``,
+    and the ratio of the two sizes.
+
+    The ratio is expressed as a percentage if ``percent`` is ``True`` in
+    a Boolean context, or as a float otherwise.
+
+    Return value is a tuple of the form
+    ``({ratio}, {size of target}, {size of diff})``
+
+    >>> compute_diff_stats([{}, 'foo', 'bar'], [], False)
+    (0.125, 16, 2)
+    >>> compute_diff_stats([{}, 'foo', 'bar'], [[0], {}])
+    (50.0, 16, 8)
+    '''
+    diff_size = float(json_length(diff))
+    target_size = json_length(target)
+    fraction = diff_size / target_size
+    if percent:
+        fraction = fraction * 100
+    return fraction, target_size, int(diff_size)
+
+
+def append_key(stanzas, left_struc, keypath=()):
+    '''Get the appropriate key for appending to the sequence ``left_struc``.
+
+    ``stanzas`` should be a diff, some of whose stanzas may modify a
+    sequence ``left_struc`` that appears at path ``keypath``.  If any of
+    the stanzas append to ``left_struc``, the return value is the
+    largest index in ``left_struc`` they address, plus one.
+    Otherwise, the return value is ``len(left_struc)`` (i.e. the index
+    that a value would have if it was appended to ``left_struc``).
+
+    >>> append_key([], [])
+    0
+    >>> append_key([[[2], 'Baz']], ['Foo', 'Bar'])
+    3
+    >>> append_key([[[2], 'Baz'], [['Quux', 0], 'Foo']], [], ['Quux'])
+    1
+
+    '''
+    keys = (s[0] for s in stanzas if s[0] == (list(keypath) + s[0][-1:]))
+    addition_key = len(left_struc)
+    for key in keys:
+        addition_key = max(addition_key, key[-1] + 1)
+    return addition_key
+
+
+def compute_keysets(left_seq, right_seq):
+    '''Compare the keys of ``left_seq`` vs. ``right_seq``.
+
+    Determines which keys ``left_seq`` and ``right_seq`` have in
+    common, and which are unique to each of the structures.  Arguments
+    should be instances of the same basic type, which must be a
+    non-terminal: i.e. :class:`list` or :class:`dict`.  If they are
+    lists, the keys compared will be integer indices.
+
+    Returns:
+        Return value is a 3-tuple of sets ``({overlap}, {left_only},
+        {right_only})``.  As their names suggest, ``overlap`` is a set
+        of keys ``left_seq`` have in common, ``left_only`` represents
+        keys only found in ``left_seq``, and ``right_only`` holds keys
+        only found in ``right_seq``.
+
+    Raises:
+        AssertionError if ``left_seq`` is not an instance of
+        ``type(right_seq)``, or if they are not of a non-terminal
+        type.
+
+    >>> (compute_keysets({'foo': None}, {'bar': None})
+    ...  == (set([]), {'foo'}, {'bar'}))
+    True
+    >>> (compute_keysets({'foo': None, 'baz': None},
+    ...                  {'bar': None, 'baz': None})
+    ...  == ({'baz'}, {'foo'}, {'bar'}))
+    True
+    >>> (compute_keysets(['foo', 'baz'], ['bar', 'baz'])
+    ...  == ({0, 1}, set([]), set([])))
+    True
+    >>> compute_keysets(['foo'], ['bar', 'baz']) == ({0}, set([]), {1})
+    True
+    >>> compute_keysets([], ['bar', 'baz']) == (set([]), set([]), {0, 1})
+    True
+
+    '''
+    assert isinstance(left_seq, type(right_seq)), (left_seq, right_seq)
+    assert type(left_seq) in NONTERMINALS, left_seq
+
+    if type(left_seq) is dict:
+        left_keyset = set(left_seq.keys())
+        right_keyset = set(right_seq.keys())
+    else:
+        left_keyset = set(range(len(left_seq)))
+        right_keyset = set(range(len(right_seq)))
+
+    overlap = left_keyset.intersection(right_keyset)
+    left_only = left_keyset - right_keyset
+    right_only = right_keyset - left_keyset
+
+    return (overlap, left_only, right_only)
+
+
+def this_level_diff(left_struc, right_struc, key=None, common=None):
+    '''Return a sequence of diff stanzas between the structures
+    ``left_struc`` and ``right_struc``, assuming that they are each at
+    the key-path ``key`` within the overall structure.
+
+    >>> (this_level_diff({'foo': 'bar', 'baz': 'quux'},
+    ...                 {'foo': 'bar'})
+    ...  == [[['baz']]])
+    True
+    >>> (this_level_diff({'foo': 'bar', 'baz': 'quux'},
+    ...                 {'foo': 'bar'}, ['quordle'])
+    ...  == [[['quordle', 'baz']]])
+    True
+
+    '''
+    out = []
+
+    if key is None:
+        key = []
+
+    if common is None:
+        common = commonality(left_struc, right_struc)
+
+    if common:
+        (overlap, left, right) = compute_keysets(left_struc, right_struc)
+        for okey in overlap:
+            if left_struc[okey] != right_struc[okey]:
+                out.append([key[:] + [okey], right_struc[okey]])
+        for okey in left:
+            out.append([key[:] + [okey]])
+        for okey in right:
+            out.append([key[:] + [okey], right_struc[okey]])
+        return out
+    elif left_struc != right_struc:
+        return [[key[:], right_struc]]
+    else:
+        return []
+
+
+def structure_comparable(left_struc, right_struc):
+    '''Test if ``left_struc`` and ``right_struc`` can be efficiently diffed.'''
+    if type(left_struc) is not type(right_struc):
+        return False
+    if type(left_struc) in TERMINALS:
+        return False
+    if len(left_struc) == 0 or len(right_struc) == 0:
+        return False
+    return True
+
+
+def commonality(left_struc, right_struc):
+    '''Return a float between ``0.0`` and ``1.0`` representing the amount
+    that the structures ``left_struc`` and ``right_struc`` have in
+    common.
+
+    Return value is computed as the fraction (elements in common) /
+    (total elements).
+
+    '''
+
+    if not structure_comparable(left_struc, right_struc):
+        return 0.0
+
+    if type(left_struc) is dict:
+        (overlap, left, right) = compute_keysets(left_struc, right_struc)
+        com = float(len(overlap))
+        tot = len(overlap.union(left, right))
+    else:
+        assert type(left_struc) in (list, tuple), left_struc
+        com = 0.0
+        for elem in left_struc:
+            if elem in right_struc:
+                com += 1
+        tot = max(len(left_struc), len(right_struc))
+
+    return com / tot
+
+
+def split_diff(stanzas):
+    '''Split a diff into modifications, deletions and insertions.
+
+    Return value is a 4-tuple of lists: the first is a list of stanzas
+    from ``stanzas`` that modify JSON objects, the second is a list of
+    stanzas that add or change elements in JSON arrays, the third is a
+    list of stanzas which delete elements from arrays, and the fourth is
+    a list of stanzas which insert elements into arrays (stanzas ending
+    in ``"i"``).
+
+    '''
+    objs = [x for x in stanzas if in_object(x[0])]
+    seqs = [x for x in stanzas if in_array(x[0])]
+    assert len(objs) + len(seqs) == len(stanzas), stanzas
+    seqs.sort(key=len)
+    lengths = [len(x) for x in seqs]
+    mod_point = bisect.bisect_left(lengths, 2)
+    ins_point = bisect.bisect_left(lengths, 3)
+    return (objs, seqs[mod_point:ins_point],
+            seqs[:mod_point], seqs[ins_point:])
+
+
+def sort_stanzas(stanzas):
+    '''Sort the stanzas in a diff.
+
+    Object changes can occur in any order, but deletions from arrays
+    have to happen last node first: ``['foo', 'bar', 'baz']`` →
+    ``['foo', 'bar']`` → ``['foo']`` → ``[]``; additions to arrays
+    have to happen leftmost-node-first: ``[]`` → ``['foo']`` →
+    ``['foo', 'bar']`` → ``['foo', 'bar', 'baz']``, and
+    insert-and-shift alterations to arrays must happen last: ``['foo',
+    'quux']`` → ``['foo', 'bar', 'quux']`` → ``['foo', 'bar', 'baz',
+    'quux']``.
+
+    Finally, stanzas are sorted in descending order of *length* of
+    keypath, so that the most deeply-nested structures are altered
+    before alterations which might change their keypaths take place.
+
+    Note that this will also sort changes to objects (dicts)
+    so that they occur first of all.
+
+    '''
+    if len(stanzas) <= 1:
+        return stanzas
+    # First we divide the stanzas using split_diff():
+    (objs, mods, dels, ins) = split_diff(stanzas)
+    # Then we sort modifications of lists in ascending order of keypath
+    # (note that we can’t tell appends from mods on the info available):
+    mods.sort(key=lambda x: x[0])
+    # Deletions from lists in descending order of keypath:
+    dels.sort(key=lambda x: x[0], reverse=True)
+    # And insert-and-shifts in ascending order of keypath:
+    ins.sort(key=lambda x: x[0])
+    # Finally, we sort by length of keypath:
+    stanzas = (objs + mods + dels + ins)
+    stanzas.sort(key=lambda s: len(s[0]), reverse=True)
+    return stanzas

--- a/tools/restconf_doc_tools/utils/json_delta/_patch.py
+++ b/tools/restconf_doc_tools/utils/json_delta/_patch.py
@@ -1,0 +1,82 @@
+# -*- encoding: utf-8 -*-
+# json_delta: a library for computing deltas between JSON-serializable
+# structures.
+# json_delta/_patch.py
+#
+# Copyright 2012‒2015 Philip J. Roberts <himself@phil-roberts.name>.
+# BSD License applies; see the LICENSE file, or
+# http://opensource.org/licenses/BSD-2-Clause
+'''Functions for applying JSON-format patches.'''
+from __future__ import unicode_literals, print_function
+import copy
+
+
+def patch(struc, diff, in_place=True):
+    '''Apply the sequence of diff stanzas ``diff`` to the structure
+    ``struc``.
+
+    By default, this function modifies ``struc`` in place; set
+    ``in_place`` to ``False`` to return a patched copy of struc
+    instead:
+
+    >>> will_change = [16]
+    >>> wont_change = [16]
+    >>> patch(will_change, [[[0]]])
+    []
+    >>> will_change
+    []
+    >>> patch(wont_change, [[[0]]], False)
+    []
+    >>> wont_change
+    [16]
+    '''
+    if not in_place:
+        struc = copy.deepcopy(struc)
+    for stanza in diff:
+        struc = patch_stanza(struc, stanza)
+    return struc
+
+
+def patch_stanza(struc, stanza):
+    '''Applies the stanza ``stanza`` to the structure ``struc`` as
+    a patch.
+
+    Note that this function modifies ``struc`` in-place into the
+    target of ``stanza``.  If ``struc`` is a :func:`tuple`, you get a
+    new tuple with the appropriate modification made:
+
+    >>> patch_stanza((17, 3.141593, None), [[1], 3.14159265])
+    (17, 3.14159265, None)
+
+    '''
+    changeback = False
+    if type(struc) is tuple:
+        changeback = True
+        struc = list(struc)[:]
+    key = stanza[0]
+    if not key:
+        struc = stanza[1]
+        changeback = False
+    elif len(key) == 1:
+        if len(stanza) == 1:
+            del struc[key[0]]
+        elif len(stanza) == 3:
+            assert stanza[2] == 'i', stanza
+            if isinstance(struc, list):
+                struc.insert(key[0], stanza[1])
+            else:
+                assert isinstance(struc, dict)
+                struc[key[0]] = stanza[1]
+        elif isinstance(struc, list) and key[0] == len(struc):
+            struc.append(stanza[1])
+        else:
+            struc[key[0]] = stanza[1]
+    else:
+        pass_key = key[:]
+        pass_struc_key = pass_key.pop(0)
+        pass_struc = struc[pass_struc_key]
+        pass_diff = [pass_key] + stanza[1:]
+        struc[pass_struc_key] = patch_stanza(pass_struc, pass_diff)
+    if changeback:
+        struc = tuple(struc)
+    return struc

--- a/tools/restconf_doc_tools/utils/json_delta/_udiff.py
+++ b/tools/restconf_doc_tools/utils/json_delta/_udiff.py
@@ -1,0 +1,519 @@
+# -*- encoding: utf-8 -*-
+# json_delta: a library for computing deltas between JSON-serializable
+# structures.
+# json_delta/_udiff.py
+#
+# Copyright 2012‒2020 Philip J. Roberts <himself@phil-roberts.name>.
+# BSD License applies; see the LICENSE file, or
+# http://opensource.org/licenses/BSD-2-Clause
+'''Functions for computing udiffs.  Main entry point: :func:`udiff`.
+
+The data structure representing a udiff that these functions all
+manipulate is a pair of lists of iterators ``(left_lines,
+right_lines)``.  These lists are expected (principally by
+:func:`generate_udiff_lines()`, which processes them), to be of the
+same length.  A pair of iterators ``(left_lines[i], right_lines[i])``
+may yield exactly the same sequence of output lines, each with ``' '``
+as the first character (representing parts of the structure the input
+and output have in common).  Alternatively, they may each yield zero
+or more lines (referring to parts of the structure that are unique to
+the inputs they represent).  In this case, all lines yielded by
+``left_lines[i]`` should begin with ``'-'``, and all lines yielded by
+``right_lines[i]`` should begin with ``'+'``.
+
+
+
+'''
+from __future__ import print_function, unicode_literals
+from ._util import TERMINALS, in_one_level, uniquify, Basestring
+from ._util import predicate_count, zip, range
+from ._diff import diff
+
+from functools import partial
+import copy
+import json
+import itertools
+
+dumps = partial(json.dumps, ensure_ascii=False)
+
+
+class Gap(object):
+    '''Class to represent gaps introduced by sequence alignment.'''
+    name = 'Gap'
+
+    def __repr__(self):
+        '''This docstring is mostly here to pacify pylint and achieve
+        100% coverage for the test suite!
+
+        >>> repr(Gap()) == '<Gap>'
+        True
+        '''
+        return '<Gap>'
+
+
+def udiff(left, right, patch=None, indent=0, use_ellipses=True, entry=True):
+    '''Render the difference between the structures ``left`` and
+    ``right`` as a string in a fashion inspired by :command:`diff -u`.
+
+    Generating a udiff is strictly slower than generating a normal
+    diff with the same option parameters, since the udiff is computed
+    on the basis of a normal diff between ``left`` and ``right``.  If
+    such a diff has already been computed (e.g. by calling
+    :func:`diff`), pass it as the ``patch`` parameter:
+
+    >>> (next(udiff({"foo": None}, {"foo": None}, patch=[])) ==
+    ...  ' {...}')
+    True
+
+    As you can see above, structures that are identical in ``left`` and
+    ``right`` are abbreviated using ``'...'`` by default.  To disable
+    this behavior, set ``use_ellipses`` to ``False``.
+
+    >>> ('\\n'.join(udiff({"foo": None}, {"foo": None},
+    ...            patch=[], use_ellipses=False)) ==
+    ... """ {
+    ...  "foo":
+    ...    null
+    ...  }""")
+    True
+
+    >>> ('\\n'.join(udiff([None, None, None], [None, None, None],
+    ...             patch=[], use_ellipses=False)) ==
+    ... """ [
+    ...   null,
+    ...   null,
+    ...   null
+    ...  ]""")
+    True
+
+    '''
+    if patch is None:
+        patch = diff(left, right, array_align='udiff', compare_lengths=False,
+                     common_key_threshold=0.0, verbose=False)
+    elif entry:
+        patch = copy.deepcopy(patch)
+
+    if not patch and type(left) in TERMINALS:
+        assert left == right, (left, right)
+        if not entry:
+            left_lines = [single_patch_band(indent, dumps(left))]
+            right_lines = [single_patch_band(indent, dumps(left))]
+        else:
+            left_lines, right_lines = ([], [])
+    elif patch and patch[0][0] == []:
+        matter = dumps(left, indent=1).split('\n')
+        left_lines = [patch_bands(indent, matter, '-')]
+        if len(patch[0]) > 1:
+            assert patch[0] == [[], right], (left, right, patch)
+            matter = dumps(right, indent=1).split('\n')
+            right_lines = [patch_bands(indent, matter, '+')]
+    elif isinstance(left, dict):
+        assert isinstance(right, dict), (left, right)
+        left_lines, right_lines = udiff_dict(left, right, patch,
+                                             indent, use_ellipses)
+    else:
+        assert isinstance(left, list), (left, right)
+        assert isinstance(right, list), (left, right)
+        left_lines, right_lines = udiff_list(left, right, patch,
+                                             indent, use_ellipses)
+
+    if entry:
+        return generate_udiff_lines(left_lines, right_lines)
+    else:
+        return (left_lines, right_lines)
+
+
+# The following functions represent functionality common to both
+# udiff_dict() and udiff_list().  The forms without the leading _ are
+# defined within the two functions, with the appropriate sequences for
+# left_lines and right_lines curried in.
+
+
+def _add_common_matter(matter, left_lines, right_lines, indent):
+    '''Add the same matter to both left_lines and right_lines.'''
+    for seq in left_lines, right_lines:
+        add_matter(seq, matter, indent)
+
+
+def _add_differing_matter(left, right, left_lines, right_lines, indent):
+    '''Add left to left_lines, and right to right_lines.'''
+    for matter, seq, sigil in ((left, left_lines, '-'),
+                               (right, right_lines, '+')):
+        if isinstance(matter, Basestring):
+            matter = single_patch_band(indent, matter, sigil)
+        add_matter(seq, matter, indent)
+
+
+def _commafy_last(left_lines, right_lines, left_comma, right_comma):
+    '''Add a comma to the last iterator in left_lines and right_lines, if
+    left_comma and right_comma are True, respectively.'''
+    if right_comma is None:
+        right_comma = left_comma
+    left_lines[-1] = commafy(left_lines[-1], left_comma)
+    right_lines[-1] = commafy(right_lines[-1], right_comma)
+
+# -----------------------------------------------------------------------------
+
+
+def curry_functions(local_ns):
+    '''Create partials of :func:`_add_common_matter`,
+    :func:`_add_differing_matter` and :func:`_commafy_last`, with
+    values for ``left_lines``, ``right_lines`` and (where appropriate)
+    ``indent`` taken from the dictionary ``local_ns``.
+
+    Appropriate defaults are also included in the partials, namely
+    ``left=None`` and ``right=None`` for :func:`_add_differing_matter`
+    and ``left_comma=True`` and ``right_comma=None`` for
+    :func:`_commafy_last`.
+
+    '''
+    dict_subset = lambda keys: {k: local_ns[k] for k in keys}
+    acm_subset = dict_subset(('indent', 'left_lines', 'right_lines'))
+    adm_subset = dict_subset(('indent', 'left_lines', 'right_lines'))
+    adm_subset.update({'left': None, 'right': None})
+    cl_subset = dict_subset(('left_lines', 'right_lines'))
+    cl_subset.update({'left_comma': True, 'right_comma': None})
+    return (partial(_add_common_matter, **acm_subset),
+            partial(_add_differing_matter, **adm_subset),
+            partial(_commafy_last, **cl_subset))
+
+
+def udiff_dict(left, right, stanzas, indent=0, use_ellipses=True):
+    '''Construct a human-readable delta between ``left`` and ``right``.
+
+    This function probably shouldn’t be called directly.  Instead, use
+    :py:func:`udiff()` with the same arguments.  :py:func:`udiff()`
+    and :py:func:`udiff_dict()` are mutually recursive, anyway.
+
+    '''
+    left_lines = []
+    right_lines = []
+
+    (add_common_matter,
+     add_differing_matter,
+     commafy_last) = curry_functions(vars())
+
+    def dump_verbatim(obj, side='left', comma=False):
+        '''Adds a verbatim JSON representation of obj to side.'''
+        matter = dumps(obj, indent=1).split('\n')
+        matter[0] = '{}: {}'.format(dumps(key), matter[0])
+        gen = patch_bands(indent, matter, '-' if side == 'left' else '+')
+        add_differing_matter(**{side: commafy(gen, comma)})
+
+    if use_ellipses:
+        keys_in_diff = uniquify([stanza[0][0] for stanza in stanzas
+                                 if stanza[0]])
+    else:
+        keys_in_diff = list(set(left.keys()).union(right.keys()))
+
+    if not (left or right):
+        add_common_matter('{}')
+        return (left_lines, right_lines)
+    if (not keys_in_diff) and use_ellipses:
+        add_common_matter('{...}')
+        return (left_lines, right_lines)
+
+    add_common_matter('{')
+    indent += 1
+
+    common_keys = set(left.keys()).union(right.keys()).difference(keys_in_diff)
+    if common_keys:
+        key = next(iter(common_keys))
+        value = next(udiff(left[key], right[key], [],
+                           indent+1, entry=False)[0][0])
+        line_matter = '{}: {}'.format(dumps(key), value.lstrip())
+        add_common_matter(line_matter)
+        if keys_in_diff or len(common_keys) > 1:
+            commafy_last()
+    if len(common_keys) > 1:
+        left_comma = any(((key in left) for key in keys_in_diff))
+        right_comma = any(((key in right) for key in keys_in_diff))
+        assert left_comma or right_comma
+        if left_comma and right_comma:
+            add_common_matter('...,')
+        elif left_comma:
+            add_differing_matter(left='...,', right='...')
+        else:
+            add_differing_matter(left='...', right='...,')
+
+    for i, key in enumerate(keys_in_diff):
+        left_comma = any(((key in left) for key in keys_in_diff[i + 1:]))
+        right_comma = any(((key in right) for key in keys_in_diff[i + 1:]))
+        sub_diff = in_one_level(stanzas, key)
+        if sub_diff == [[[]]]:  # Handle deletions from left
+            dump_verbatim(left[key], 'left', left_comma)
+        elif key not in left:  # Handle additions
+            dump_verbatim(right[key], 'right', right_comma)
+        else:  # Handle modifications
+            [left_side, right_side] = udiff(
+                left[key], right[key], sub_diff, indent + 1,
+                use_ellipses, entry=False
+            )
+            add_common_matter('{}:'.format(dumps(key)))
+            add_differing_matter(left=left_side, right=right_side)
+            commafy_last(left_comma=left_comma, right_comma=right_comma)
+        if i != (len(keys_in_diff) - 1):
+            add_common_matter('')
+
+    indent -= 1
+    add_common_matter('}')
+    return left_lines, right_lines
+
+
+def udiff_list(left, right, stanzas, indent=0, use_ellipses=True):
+    '''Construct a human-readable delta between ``left`` and ``right``.
+
+    This function probably shouldn’t be called directly.  Instead, use
+    :py:func:`udiff()` with the same arguments.  :py:func:`udiff()`
+    and :py:func:`udiff_list()` are mutually recursive, anyway.
+
+    '''
+    left_lines = []
+    right_lines = []
+
+    (add_common_matter,
+     add_differing_matter,
+     commafy_last) = curry_functions(vars())
+
+    def dump_verbatim(obj, side='left', comma=False):
+        '''Adds a verbatim JSON representation of obj to side.'''
+        matter = dumps(obj, indent=1).split('\n')
+        gen = patch_bands(indent+1, matter, '-' if side == 'left' else '+')
+        add_differing_matter(**{side: commafy(gen, comma)})
+
+    if not (left or right):
+        add_common_matter('[]')
+        return (left_lines, right_lines)
+    if not stanzas and use_ellipses:
+        assert left == right, (left, right)
+        material = '[...({})]'.format(len(right))
+        add_common_matter(material)
+        return (left_lines, right_lines)
+
+    add_common_matter('[')
+    left_a, right_a = reconstruct_alignment(left, right, stanzas)
+    keys = (i for i in range(len(left_a)) if left_a[i] != right_a[i])
+
+    def compute_commas(idx):
+        '''Determine whether commas need to be appended to the patch bands
+        representing the structures at left_a[idx] and right_a[idx].
+
+        Output is a pair of bools.
+        '''
+        out = []
+        for seq in left_a, right_a:
+            out.append(any(((not isinstance(elem, Gap))
+                            for elem in seq[idx:])))
+        return tuple(out)
+
+    pos = 0
+    while pos < len(left_a):
+        try:
+            key = next(keys)
+            sub_diff = in_one_level(
+                stanzas, predicate_count(left_a[:key],
+                                         lambda x: not isinstance(x, Gap)))
+        except StopIteration:
+            key = len(left_a) - 1
+            sub_diff = []
+        assert key >= pos, (key, pos)
+        pos_diff = key - pos
+
+        if use_ellipses:
+            if pos_diff >= 1:
+                assert left_a[pos] == right_a[pos], (left_a, right_a, pos)
+                left_ext, right_ext = udiff(
+                    left_a[pos], right_a[pos], [],
+                    indent+1, use_ellipses, entry=False
+                )
+                add_differing_matter(left=left_ext, right=right_ext)
+            if pos_diff > 2:
+                commafy_last()
+                matter = '...({:d})'.format(pos_diff - 2)
+                add_common_matter(matter, indent=indent+1)
+            if pos_diff >= 2:
+                assert left_a[key-1] == right_a[key-1], \
+                    (left_a, right_a, key - 1)
+                commafy_last()
+                left_ext, right_ext = udiff(
+                    left_a[key-1], right_a[key-1], [],
+                    indent+1, use_ellipses, entry=False
+                )
+                add_differing_matter(left=left_ext, right=right_ext)
+        else:
+            for prepos in range(pos, key):
+                left_ext, right_ext = udiff(
+                    left_a[prepos], right_a[prepos],
+                    in_one_level(stanzas, prepos),
+                    indent+1, use_ellipses, entry=False
+                )
+                add_differing_matter(left=left_ext, right=right_ext)
+                if (key - prepos > 1):
+                    commafy_last()
+
+        left_comma, right_comma = compute_commas(key)
+
+        if left_comma and right_comma and pos_diff >= 1:
+            commafy_last()
+        elif left_comma and pos_diff >= 1:
+            add_differing_matter(left=',')
+        elif right_comma and pos_diff >= 1:
+            add_differing_matter(right=',')
+
+        left_comma, right_comma = compute_commas(key+1)
+
+        if isinstance(right_a[key], Gap):
+            dump_verbatim(left_a[key], 'left', left_comma)
+        elif isinstance(left_a[key], Gap):
+            dump_verbatim(right_a[key], 'right', right_comma)
+        else:
+            left_ext, right_ext = udiff(left_a[key], right_a[key], sub_diff,
+                                        indent+1, use_ellipses, entry=False)
+            add_differing_matter(left=left_ext, right=right_ext)
+            if left_comma and right_comma:
+                commafy_last()
+            elif left_comma:
+                add_differing_matter(left=',')
+            elif right_comma:
+                add_differing_matter(right=',')
+        pos = key + 1
+
+    add_common_matter(']')
+    return (left_lines, right_lines)
+
+
+def patch_bands(indent, material, sigil=' '):
+    '''Generate appropriately indented patch bands, with ``sigil`` as
+    the first character.'''
+    indent = ' ' * indent
+    for line in material:
+        yield ''.join((sigil, indent, line))
+
+
+def single_patch_band(indent, line, sigil=' '):
+    '''Convenience function returning an iterable that generates a
+    single patch band.'''
+    return patch_bands(indent, (line,), sigil)
+
+
+def commafy(gen, comma=True):
+    '''Yield from ``gen``, ensuring that the final result ends with
+    a comma iff ``comma`` is ``True``.
+
+    >>> gen = ['Example line']
+    >>> next(commafy(iter(gen))) == 'Example line,'
+    True
+    >>> next(commafy(iter(gen), False)) == 'Example line'
+    True
+    >>> gen = ['Line with a comma at the end,']
+    >>> (next(commafy(iter(gen), comma=True))
+    ...  == next(commafy(iter(gen), comma=False))
+    ...  == 'Line with a comma at the end,')
+    True
+    '''
+    comma = ',' if comma else ''
+    prev = next(gen)
+    for line in gen:
+        yield prev
+        prev = line
+    if not prev.endswith(','):
+        yield '{}{}'.format(prev, comma)
+    else:
+        yield prev
+
+
+def add_matter(seq, matter, indent):
+    '''Add material to ``seq``, treating it appropriately for its
+    type.
+
+    ``matter`` may be an iterator, in which case it is appended to
+    ``seq``.  If it is a sequence, it is assumed to be a sequence of
+    iterators, the sequence is concatenated onto ``seq``.  If
+    ``matter`` is a string, it is turned into a patch band using
+    :py:func:`single_patch_band`, which is appended.  Finally, if
+    ``matter`` is ``None``, an empty iterable is appended to ``seq``.
+
+    This function is a udiff-forming primitive, called by more
+    specific functions defined within :py:func:`udiff_dict` and
+    :py:func:`udiff_list`.
+
+    '''
+    if isinstance(matter, Basestring):
+        seq.append(single_patch_band(indent, matter))
+    elif matter is None:
+        seq.append(iter(()))
+    elif isinstance(matter, list) or isinstance(matter, tuple):
+        seq.extend(matter)
+    else:
+        seq.append(matter)
+
+
+def reconstruct_alignment(left, right, stanzas):
+    '''Reconstruct the sequence alignment between the lists ``left``
+    and ``right`` implied by ``stanzas``.'''
+    indices = list(range(len(left)))
+
+    for stanza in stanzas:
+        if len(stanza[0]) == 1:
+            key = stanza[0][0]
+            if len(stanza) == 1:
+                del indices[key]
+            elif len(stanza) == 3:
+                assert stanza[2] == 'i', stanza
+                indices.insert(key, Gap())
+            else:
+                assert len(stanza) == 2, stanza
+
+    left_a = []
+    right_a = []
+    origin = -1
+    elems = iter(right)
+    for (next_point, next_elem) in zip(indices, elems):
+        if isinstance(next_point, Gap):
+            left_a.append(next_point)
+            right_a.append(next_elem)
+        else:
+            left_a.extend(left[origin+1:next_point+1])
+            right_a.extend([Gap()] * (next_point - origin - 1))
+            right_a.append(next_elem)
+            origin = next_point
+    if isinstance(next_point, Gap):
+        next_point = origin
+    left_a.extend(left[next_point+1:])
+    right_a.extend(elems)
+
+    short_a = min(left_a, right_a, key=len)
+    short_a.extend([Gap()] * abs(len(left_a) - len(right_a)))
+    assert len(left_a) == len(right_a), (left_a, right_a)
+    return left_a, right_a
+
+
+def generate_udiff_lines(left, right):
+    '''Combine the diff lines from ``left`` and ``right``, and
+    generate the lines of the resulting udiff.'''
+    assert len(left) == len(right), (left, right)
+    right_gens = iter(right)
+    for left_g in left:
+        right_g = next(right_gens)
+        left_line = next(left_g, None)
+        if (left_line is not None) and (left_line[0] == ' '):
+            left_g = itertools.chain((left_line,), left_g)
+            for line in left_g:
+                right_line = next(right_g)
+                if right_line.endswith(',') and not line.endswith(','):
+                    line = line + ','
+                if not right_line.endswith(',') and line.endswith(','):
+                    right_line = right_line + ','
+                assert line == right_line, (line, right_line)
+                yield line
+        else:
+            if left_line is not None:
+                assert left_line[0] == '-', left_line
+                yield left_line
+                for line in left_g:
+                    assert line[0] == '-', line
+                    yield line
+
+            for line in right_g:
+                assert line[0] == '+', line
+                yield line

--- a/tools/restconf_doc_tools/utils/json_delta/_upatch.py
+++ b/tools/restconf_doc_tools/utils/json_delta/_upatch.py
@@ -1,0 +1,220 @@
+# -*- encoding: utf-8 -*-
+from __future__ import print_function, unicode_literals
+import json
+
+from ._util import key_tracker, in_array, nearest_of
+from ._diff import split_diff
+from . import _patch
+
+
+def upatch(struc, udiff, reverse=False, in_place=True):
+    '''Apply a patch as output by :func:`json_delta.udiff()` to ``struc``.
+
+    As with :func:`json_delta.patch`, ``struc`` is modified in place by
+    default.  Set the parm ``in_place`` to ``False`` if this is not the
+    desired behaviour.
+
+    The udiff format has enough information in it that this
+    transformation can be applied in reverse: i.e. if ``udiff`` is the
+    output of ``udiff(left, right)``, you can reconstruct ``right``
+    given ``left`` and ``udiff`` (by running ``upatch(left, udiff)``),
+    or you can also reconstruct ``left`` given ``right`` and udiff (by
+    running ``upatch(right, udiff, reverse=True)``).  This is not
+    possible for JSON-format diffs, since a ``[keypath]`` stanza
+    (meaning “delete the structure at ``keypath``”) does not record what
+    the deleted structure was.
+
+    '''
+    diff = reconstruct_diff(udiff, reverse)
+    return _patch.patch(struc, diff, in_place)
+
+
+def ellipsis_handler(jstring, point, key):
+    '''Extends :func:`key_tracker` to handle the ``…`` construction.'''
+    out_key = key[:]
+    if jstring[point] == '.':
+        if point+3 < len(jstring) and jstring[point:point+3] == '...':
+            point += 3
+            if in_array(key, accept_None=True) and jstring[point] == '(':
+                increment = ''
+                point += 1
+                while point < len(jstring) and jstring[point] != ')':
+                    assert jstring[point] in '0123456789'
+                    increment += jstring[point]
+                    point += 1
+                out_key[-1] += int(increment) - 1
+            point -= 1
+        else:
+            assert jstring[point-1] in '0123456789'
+            assert jstring[point+1] in '0123456789'
+    return (point, out_key)
+
+
+def udiff_key_tracker(udiff, point=0, start_key=None):
+    '''Find points within the udiff where the active keypath changes.'''
+    for point, key in key_tracker(udiff, point, start_key, ellipsis_handler):
+        yield point, key
+
+
+def sort_stanzas(stanzas):
+    '''Sorts the stanzas in a diff.
+
+    :func:`reconstruct_diff` works on different assumptions from
+    :func:`json_delta._diff.needle_diff` when it comes to stanzas
+    altering arrays: keys in such stanzas relate to the element’s
+    position within the array’s longest intermediate representation
+    during the transformation (that is after all insert-and-shifts,
+    after all appends, but *before* any deletions).  This function sorts
+    ``stanzas`` to reflect that order of operations.
+
+    As with :func:`json_delta._diff.sort_stanzas` (which see), stanzas
+    are sorted for length so the most deeply-nested structures get
+    their modifications first.
+
+    '''
+    if len(stanzas) <= 1:
+        return stanzas
+    (objs, mods, dels, ins) = split_diff(stanzas)
+    mods.sort(key=lambda x: x[0][-1])
+    ins.sort(key=lambda x: x[0][-1])
+    ins.sort(key=lambda x: len(x[0]))
+    dels.sort(key=lambda x: x[0][-1], reverse=True)
+    dels.sort(key=lambda x: len(x[0]), reverse=True)
+    stanzas = ins + objs + mods + dels
+    return stanzas
+
+
+def is_none_key(key):
+    '''Is the last element of ``key`` ``None``?'''
+    return key and key[-1] is None
+
+
+def skip_key(point, key, origin, keys, predicate):
+    '''Find the next result in ``keys`` for which ``predicate(key)`` is ``False``.
+
+    If none is found, or if ``key`` is already such a result, the
+    return value is ``(point, key)``.
+
+    '''
+    while predicate(key):
+        try:
+            p, key = next(keys)
+        except StopIteration:
+            break
+        point = origin + p
+    return point, key
+
+
+def reconstruct_diff(udiff, reverse=False):
+    '''Turn a udiff back into a JSON-format diff.
+
+    Set ``reverse`` to ``True`` to generate a reverse diff (i.e. swap
+    the significance of line-initial ``+`` and ``-``).
+
+    Header lines (if present) are ignored:
+
+    >>> udiff = """--- <stdin>
+    ... +++ <stdin>
+    ... -false
+    ... +true"""
+    >>> reconstruct_diff(udiff)
+    [[[], True]]
+    >>> reconstruct_diff(udiff, reverse=True)
+    [[[], False]]
+    '''
+    del_sigil = '+' if reverse else '-'
+    add_sigil = '-' if reverse else '+'
+    deletes = []
+    diff = []
+    del_key = []
+    add_key = []
+    point = 0
+    # dec = JSONDecoder()
+
+    def scrub_span(point, next_point, sigil):
+        span = udiff[point:next_point-1]
+        span = span.replace('\n{}'.format(sigil), '').strip('\r\n\t ')
+        return span
+
+    def gen_stanzas(point, max_point, adding=True):
+        point += 1
+        key = add_key if adding else del_key
+        sigil = add_sigil if adding else del_sigil
+        keys = udiff_key_tracker(udiff[point:max_point], 0, key)
+        origin = point
+
+        def build_output():
+            span = scrub_span(point, next_point, sigil)
+            if span and adding:
+                return (next_key, [list(key), json.loads(span)])
+            elif span:
+                return (next_key, [list(key)])
+
+        point, key = skip_key(point, key, origin, keys, is_none_key)
+        next_key = top_key = key
+        keys = ((p, k) for (p, k) in keys if len(k) == len(top_key))
+
+        if not is_none_key(key):
+            for p, next_key in keys:
+                next_point, next_key = skip_key(
+                    origin + p, next_key, origin, keys, lambda k: k == key
+                )
+                if next_key == tuple(key):
+                    break
+
+                out = build_output()
+                if out is not None:
+                    yield out
+
+                point, key = skip_key(
+                    next_point, next_key, origin, keys, is_none_key
+                )
+
+        next_point = max_point
+        if not is_none_key(key):
+            out = build_output()
+            if out is not None:
+                yield out
+
+    if point + 3 <= len(udiff) and udiff[point:point+3] == '---':
+        point = udiff[point:].find('\n') + point + 1
+    if point + 3 <= len(udiff) and udiff[point:point+3] == '+++':
+        point = udiff[point:].find('\n') + point + 1
+
+    while point < len(udiff):
+        if udiff[point] == ' ':
+            if in_array(del_key, accept_None=True):
+                assert in_array(add_key, accept_None=True)
+                add_key = del_key = max(add_key, del_key)
+            max_point = (nearest_of(udiff[point:], '\n{}'.format(del_sigil),
+                                                   '\n{}'.format(add_sigil))
+                         + point + 1)
+            for p, del_key in udiff_key_tracker(udiff[point:max_point],
+                                                0, del_key):
+                pass
+            for p, add_key in udiff_key_tracker(udiff[point:max_point],
+                                                0, add_key):
+                pass
+        elif udiff[point] == del_sigil:
+            max_point = (
+                nearest_of(udiff[point:], '\n{}'.format(add_sigil), '\n ')
+                + point + 1
+            )
+            for del_key, stanza in gen_stanzas(point, max_point, False):
+                deletes.append(stanza)
+        else:
+            assert udiff[point] == add_sigil
+            max_point = (
+                nearest_of(udiff[point:], '\n{}'.format(del_sigil), '\n ')
+                + point + 1
+            )
+            for add_key, stanza in gen_stanzas(point, max_point):
+                diff.append(stanza)
+        point = max_point
+    keys_in_diff = [stanza[0] for stanza in diff]
+    for stanza in diff:
+        key = stanza[0]
+        if (in_array(key, accept_None=True) and [key] not in deletes):
+            stanza.append('i')
+    diff.extend((d for d in deletes if d[0] not in keys_in_diff))
+    return sort_stanzas(diff)

--- a/tools/restconf_doc_tools/utils/json_delta/_util.py
+++ b/tools/restconf_doc_tools/utils/json_delta/_util.py
@@ -1,0 +1,814 @@
+# -*- coding: utf-8 -*-
+# json_delta: a library for computing deltas between JSON-serializable
+# structures.
+# json_delta/_util.py
+#
+# Copyright 2012‒2020 Philip J. Roberts <himself@phil-roberts.name>.
+# BSD License applies; see the LICENSE file, or
+# http://opensource.org/licenses/BSD-2-Clause
+'''Utility functions and constants used by more than one submodule.
+
+The majority of python 2/3 compatibility shims also appear in this
+module.
+
+'''
+
+from __future__ import print_function, unicode_literals
+
+import sys
+import json
+import codecs
+import itertools
+
+try:
+    from itertools import izip as zip
+except ImportError:
+    zip = zip
+
+try:
+    Basestring = basestring
+except NameError:
+    Basestring = str
+
+try:
+    IntegerTypes = (int, long)
+except NameError:
+    IntegerTypes = (int,)
+
+TERMINALS = (str, int, float, bool, type(None))
+try:
+    TERMINALS += (unicode, long)
+except NameError:
+    pass
+NONTERMINALS = (list, tuple, dict)
+SERIALIZABLE_TYPES = TERMINALS + NONTERMINALS
+NUMERIC_TYPES = IntegerTypes + (float,)
+
+ENCODINGS = ('utf_8', 'utf_16_le', 'utf_16_be', 'utf_32_le', 'utf_32_be')
+
+try:
+    range = xrange
+except NameError:
+    range = range
+
+dump_test = json.dumps((True, False), indent=1)
+SPACE_AFTER_COMMA = ', ' in dump_test
+
+
+def licit_starts(start_chars='{}[]"-0123456789tfn \t\n\r'):
+    '''Compute the bytestrings a UTF-x encoded string can begin with.
+
+    This function is intended for encoding detection when the
+    beginning of the encoded string must be one of a limited set of
+    characters, as for JSON or the udiff format.  The argument
+    ``start_chars`` must be an iterable of valid beginnings.
+
+    '''
+    bom_attr_name = lambda e: 'BOM_{}'.format(e.upper().replace('_', '', 1))
+    out = {getattr(codecs, bom_attr_name(k)): k[:6] for k in ENCODINGS}
+    out[codecs.BOM_UTF8] = 'utf_8_sig'
+    for encoding, start in itertools.product(ENCODINGS, start_chars):
+        start = start.encode(encoding)
+        assert start not in out, (start, out[start], encoding)
+        out[start] = encoding
+    return out
+
+
+JSON_STARTS = licit_starts('{}[]"-0123456789tfn \t\n\r')
+UDIFF_STARTS = licit_starts(' +-')
+
+
+def sniff_encoding(bytestring, starts=JSON_STARTS, complete=True):
+    r'''Determine the encoding of a UTF-x encoded string.
+
+    The argument ``starts`` must be a mapping of bytestrings the input
+    can begin with onto the encoding that such a beginning would
+    represent (see :func:`licit_starts` for a function that can build
+    such a mapping).
+
+    The ``complete`` flag signifies whether the input represents the
+    entire string: if it is set ``False``, the function will attempt
+    to determine the encoding, but will raise a ``UnicodeError`` if it
+    is ambiguous.  For example, an input of ``b'\xff\xfe'`` could be
+    the UTF-16 little-endian byte-order mark, or, if the input is
+    incomplete, it could be the first two characters of the UTF-32-LE
+    BOM:
+
+    >>> sniff_encoding(b'\xff\xfe') == 'utf_16'
+    True
+    >>> sniff_encoding(b'\xff\xfe', complete=False)
+    Traceback (most recent call last):
+        ...
+    UnicodeError: String encoding is ambiguous.
+
+    '''
+    iteritems = getattr(starts, 'iteritems', starts.items)
+    test = (lambda k, p: k == p if complete
+            else lambda k, p: k.startswith(p))
+    candidates = set()
+    for limit in range(min(4, len(bytestring)), 0, -1):
+        prefix = bytestring[:limit]
+        candidates = set([v for k, v in iteritems() if test(k, prefix)])
+        if len(candidates) == 1:
+            return next(iter(candidates))
+    if not candidates:
+        raise ValueError('String does not begin with '
+                         'any of the specified start chars.')
+    else:
+        raise UnicodeError('String encoding is ambiguous.')
+
+
+def decode_json(file_or_str):
+    '''Decode a JSON file-like object or string.
+
+    The following doctest is probably pointless as documentation.  It is
+    here so json-delta can claim 100% code coverage for its test suite!
+
+    >>> try:
+    ...     from StringIO import StringIO
+    ... except ImportError:
+    ...     from io import StringIO
+    >>> foo = '[]'
+    >>> decode_json(foo)
+    []
+    >>> decode_json(StringIO(foo))
+    []
+    '''
+    if isinstance(file_or_str, bytes):
+        file_or_str = file_or_str.decode(
+            sniff_encoding(file_or_str, JSON_STARTS)
+        )
+    if isinstance(file_or_str, Basestring):
+        return json.loads(file_or_str)
+    return decode_json(read_bytestring(file_or_str))
+
+
+def decode_udiff(file_or_str):
+    r'''Decode a file-like object or bytestring udiff into a unicode string.
+
+    The udiff may be encoded in UTF-8, -16 or -32 (with or without BOM):
+
+    >>> udiff = u'- true\n+ false'
+    >>> decode_udiff(udiff.encode('utf_32_be')) == udiff
+    True
+    >>> try:
+    ...     from StringIO import StringIO
+    ... except ImportError:
+    ...     from io import BytesIO as StringIO
+    >>> decode_udiff(StringIO(udiff.encode('utf-8-sig'))) == udiff
+    True
+
+    An empty string is a valid udiff; this function will convert it to
+    a unicode string:
+
+    >>> decode_udiff(b'') == u''
+    True
+
+    The function is idempotent: if you pass it a unicode string, it
+    will be returned unmodified:
+
+    >>> decode_udiff(udiff) is udiff
+    True
+
+    If you pass it a non-empty bytestring that cannot be interpreted
+    as beginning with ``' '``, ``'+'``, ``'-'`` or a BOM in any
+    encoding, a ``ValueError`` is raised:
+
+    >>> decode_udiff(b':-)')
+    Traceback (most recent call last):
+        ...
+    ValueError: String does not begin with any of the specified start chars.
+
+    '''
+    if isinstance(file_or_str, bytes):
+        if not file_or_str:
+            file_or_str = u''
+        else:
+            file_or_str = file_or_str.decode(
+                sniff_encoding(file_or_str, UDIFF_STARTS)
+            )
+    if isinstance(file_or_str, Basestring):
+        return file_or_str
+    return decode_udiff(read_bytestring(file_or_str))
+
+
+def read_bytestring(file):
+    '''Read the contents of ``file`` as a :class:`bytes` object.'''
+    file = getattr(file, 'buffer', file)
+    bytestring = file.read()
+    return bytestring
+
+
+def predicate_count(iterable, predicate=lambda x: True):
+    '''Count items ``x`` in ``iterable`` such that ``predicate(x)``.
+
+    The default ``predicate`` is ``lambda x: True``, so
+    ``predicate_count(iterable)`` will count the values generated by
+    ``iterable``.  Note that if the iterable is a generator, this
+    function will exhaust it, and if it is an infinite generator, this
+    function will never return!
+
+    >>> predicate_count([True] * 16)
+    16
+    >>> predicate_count([True, True, False, True, True], lambda x: x)
+    4
+
+    '''
+    count = 0
+    for item in iterable:
+        if predicate(item):
+            count += 1
+    return count
+
+
+def uniquify(obj, key=lambda x: x):
+    '''Remove duplicate elements from a list while preserving order.
+
+    ``key`` works as for :func:`min`, :func:`max`, etc. in the
+    standard library.
+
+    '''
+    seen = set()
+    seen_add = seen.add
+    return [
+        x for x in obj if (key(x) not in seen and not seen_add(key(x)))
+    ]
+
+
+def _load_and_func(func, parm1=None, parm2=None, both=None, **flags):
+    '''Decode JSON-serialized parameters and apply func to them.'''
+    if (parm1 is not None) and (parm2 is not None):
+        return func(decode_json(parm1), decode_json(parm2), **flags)
+    else:
+        assert (both is not None), (parm1, parm2, both)
+        [parm1, parm2] = decode_json(both)
+        return func(parm1, parm2, **flags)
+
+
+def stanzas_addressing(stanzas, keypath):
+    '''Find diff stanzas modifying the structure at ``keypath``.
+
+    The purpose of this function is to keep track of changes made to
+    the overall structure by stanzas earlier in the sequence, e.g.:
+
+    >>> struc = [
+    ...     'foo',
+    ...     'bar', [
+    ...         'baz'
+    ...     ]
+    ... ]
+    >>> stanzas = [
+    ...     [ [2, 1], 'quux'],
+    ...     [ [0] ],
+    ...     [ [1, 2], 'quordle']
+    ... ]
+    >>> (stanzas_addressing(stanzas, [2])
+    ...  == [
+    ...   [ [1], 'quux' ],
+    ...   [ [2], 'quordle' ]
+    ...  ])
+    True
+
+    ``stanzas[0]`` and ``stanzas[2]`` both address the same element of
+    ``struc`` — the list that starts off as ``['baz']``, even though
+    their keypaths are completely different, because the diff stanza
+    ``[[0]]`` moves the list ``['baz']`` from index 2 of ``struc`` to
+    index 1.
+
+    The return value is a sub-diff: a list of stanzas fit to modify
+    the element at ``keypath`` within the overall structure.
+
+    '''
+    keypath = keypath[:]
+    out = []
+    for stanza in stanzas:
+        stanza_keypath = stanza[0]
+        if stanza_keypath[:len(keypath)] == keypath:
+            out.append([stanza_keypath[len(keypath):]] + stanza[1:])
+        elif (in_array(stanza_keypath)
+              and len(stanza) in (1, 3)
+              and len(stanza_keypath) <= len(keypath)):
+            kp_mutand_pos = len(stanza_keypath) - 1
+            assert (keypath[kp_mutand_pos] != stanza_keypath[-1]), \
+                (stanza, keypath)
+            if keypath[kp_mutand_pos] > stanza_keypath[-1]:
+                if len(stanza) == 1:
+                    keypath[kp_mutand_pos] -= 1
+                else:
+                    assert stanza == [stanza_keypath, stanza[1], 'i'], stanza
+                    keypath[kp_mutand_pos] += 1
+    return out
+
+
+def in_one_level(stanzas, key):
+    return stanzas_addressing(stanzas, [key])
+
+
+def compact_json_dumps(obj):
+    '''Compute the most compact possible JSON representation of ``obj``.
+
+    >>> test = {
+    ...             'foo': 'bar',
+    ...             'baz':
+    ...                ['quux', 'spam',
+    ...       'eggs']
+    ... }
+    >>> compact_json_dumps(test) in (
+    ...     '{"foo":"bar","baz":["quux","spam","eggs"]}',
+    ...     '{"baz":["quux","spam","eggs"],"foo":"bar"}'
+    ... )
+    True
+    >>>
+    '''
+    return json.dumps(obj, indent=None, separators=(',', ':'),
+                      ensure_ascii=False)
+
+
+def all_paths(struc):
+    '''Generate key-paths to every node in ``struc``.
+
+    Both terminal and non-terminal nodes are visited, like so:
+
+    >>> paths = [x for x in all_paths({'foo': None, 'bar': ['baz', 'quux']})]
+    >>> [] in paths # ([] is the path to ``struc`` itself.)
+    True
+    >>> ['foo'] in paths
+    True
+    >>> ['bar'] in paths
+    True
+    >>> ['bar', 0] in paths
+    True
+    >>> ['bar', 1] in paths
+    True
+    >>> len(paths)
+    5
+    '''
+    yield []
+    if isinstance(struc, dict):
+        keys = struc.keys()
+    elif isinstance(struc, list):
+        keys = range(len(struc))
+    else:
+        return
+    for key in keys:
+        for subkey in all_paths(struc[key]):
+            yield [key] + subkey
+
+
+def follow_path(struc, path):
+    '''Retrieve the value found at the key-path ``path`` within ``struc``.'''
+    if not path:
+        return struc
+    else:
+        return follow_path(struc[path[0]], path[1:])
+
+
+def check_diff_structure(diff):
+    '''Return ``diff`` (or ``True``) if it is structured as a sequence
+    of ``diff`` stanzas.  Otherwise return ``False``.
+
+    ``[]`` is a valid diff, so if it is passed to this function, the
+    return value is ``True``, so that the return value is always true
+    in a Boolean context if ``diff`` is valid.
+
+    >>> check_diff_structure('This is certainly not a diff!')
+    False
+    >>> check_diff_structure([])
+    True
+    >>> check_diff_structure([None])
+    False
+    >>> example_valid_diff = [[["foo", 6, 12815316313, "bar"], None]]
+    >>> check_diff_structure(example_valid_diff) == example_valid_diff
+    True
+    >>> check_diff_structure([[["foo", 6, 12815316313, "bar"], None],
+    ...                       [["foo", False], True]])
+    False
+    '''
+    if diff == []:
+        return True
+    if not isinstance(diff, list):
+        return False
+    for stanza in diff:
+        conditions = (lambda s: isinstance(s, list),
+                      lambda s: isinstance(s[0], list),
+                      lambda s: len(s) in (1, 2, 3),
+                      lambda s: len(s) != 3 or s[2] == 'i')
+        for condition in conditions:
+            if not condition(stanza):
+                return False
+        for key in stanza[0]:
+            if not (type(key) in IntegerTypes or isinstance(key, Basestring)):
+                # Checking type because isinstance(False, int) == True!
+                return False
+    return diff
+
+
+def in_x_error(key, offender):
+    '''Build the instance of ``ValueError`` :func:`in_object` and
+    :func:`in_array` raise if ``keypath`` is invalid.'''
+    msg = ('keypath elements must be instances of '
+           'str, unicode, int or long,\n'
+           '    not {} (key[{}] == {})'.format(
+               type(offender).__name__, key.index(offender), repr(offender)
+           ))
+    return ValueError(msg)
+
+
+def in_object(key, accept_None=False):
+    '''Should the keypath ``key`` point at a JSON object (``{}``)?
+
+    Works by testing whether ``key[-1]`` is a string or (where appropriate)
+    :func:`unicode`:
+
+    >>> in_object(["foo"])
+    True
+    >>> in_object([u'bar'])
+    True
+
+    Returns ``False`` if ``key`` addresses an array…
+
+    >>> in_object([u'bar', 16])
+    False
+    >>> import sys
+    >>> False if sys.version >= '3' else eval("in_object([u'bar', 16L])")
+    False
+
+    …if ``key == []``…
+
+    >>> in_object([])
+    False
+
+    If the ``accept_None`` flag is set, this function will also return
+    ``True`` if ``key[-1] is None`` (this functionality is used by
+    :func:`key_tracker`, to signal points within a JSON string where a
+    new object key is expected, but not yet found).
+
+    >>> in_object([None])
+    Traceback (most recent call last):
+        ...
+    ValueError: keypath elements must be instances of str, unicode, int or long,
+        not NoneType (key[0] == None)
+
+    >>> in_object([None], True)
+    True
+    >>> in_object([None], accept_None=True)
+    True
+
+    Raises a ``ValueError`` if ``key`` is not a valid keypath:
+
+    >>> in_object(['foo', {}])
+    Traceback (most recent call last):
+        ...
+    ValueError: keypath elements must be instances of str, unicode, int or long,
+        not dict (key[1] == {})
+
+    >>> in_object([False, u'foo'])
+    Traceback (most recent call last):
+        ...
+    ValueError: keypath elements must be instances of str, unicode, int or long,
+        not bool (key[0] == False)
+
+    '''
+
+    try:
+        offender = next((k for k in key[:-1]
+                         if (not isinstance(k, Basestring)
+                             and type(k) not in IntegerTypes)))
+    except StopIteration:
+        pass
+    else:
+        raise in_x_error(key, offender)
+    out = bool(key and (isinstance(key[-1], Basestring)
+                        or (accept_None and key[-1] is None)))
+    if not out and key and type(key[-1]) not in IntegerTypes:
+        raise in_x_error(key, key[-1])
+    return out
+
+
+def in_array(key, accept_None=False):
+    '''Should the keypath ``key`` point at a JSON array (``[]``)?
+
+    Works by testing whether ``key[-1]`` is an :class:`int` or
+    (where appropriate) :class:`long`:
+
+    >>> in_array([u'bar', 16])
+    True
+    >>> import sys
+    >>> sys.version >= '3' or eval("in_array([u'foo', 94L])")
+    True
+
+    Returns ``False`` if ``key`` addresses a non-array object…
+
+    >>> in_array(["foo"])
+    False
+    >>> in_array([u'bar'])
+    False
+
+    …or if ``key == []`` (as in that case there’s no way of knowing
+    whether ``key`` addresses an object or an array).
+
+    >>> in_array([])
+    False
+
+    If the ``accept_None`` flag is set, this function will not raise a
+    ``ValueError`` if ``key[-1] is None`` (keypaths of this form are
+    used by :func:`key_tracker`, to signal points within a JSON string
+    where a new object key is expected, but not yet found).
+
+    >>> in_array([None])
+    Traceback (most recent call last):
+        ...
+    ValueError: keypath elements must be instances of str, unicode, int or long,
+        not NoneType (key[0] == None)
+
+    >>> in_array([None], True)
+    False
+    >>> in_array([None], accept_None=True)
+    False
+
+    Otherwise, a ``ValueError`` is raised if ``key`` is not a valid keypath:
+
+    >>> keypath = [{str("spam"): str("spam")}, "pickled eggs and spam", 7]
+    >>> in_array(keypath)
+    Traceback (most recent call last):
+        ...
+    ValueError: keypath elements must be instances of str, unicode, int or long,
+        not dict (key[0] == {'spam': 'spam'})
+
+    '''
+    try:
+        offender = next((k for k in key[:-1]
+                         if (not isinstance(k, Basestring)
+                             and type(k) not in IntegerTypes)))
+    except StopIteration:
+        pass
+    else:
+        raise in_x_error(key, offender)
+    if accept_None and key and key[-1] is None:
+        return False
+    out = bool(key and type(key[-1]) in IntegerTypes)
+    if not out and key and not isinstance(key[-1], Basestring):
+        raise in_x_error(key, key[-1])
+    return out
+
+
+def nearest_of(string, *subs):
+    '''Find the index of the substring in ``subs`` that occurs earliest in
+    ``string``, or ``len(string)`` if none of them do.'''
+    return min((string.find(x) if x in string else len(string) for x in subs))
+
+
+def skip_string(jstring, point):
+    r'''Assuming ``jstring`` is a string, and ``jstring[point]`` is a ``"`` that
+    starts a JSON string, return ``x`` such that ``jstring[x-1]`` is
+    the ``"`` that terminates the string.
+
+    When a ``"`` is found, it is necessary to check that it is not
+    escaped by a preceding backslash.  As a backslash may itself be
+    escaped, this amounts to checking that the number of backslashes
+    immediately preceding the ``"`` is even (counting 0 as an even
+    number):
+
+    >>> test_string = r'"Fred \"Foonly\" McQuux"'
+    >>> skip_string(test_string, 0) == len(test_string)
+    True
+    >>> backslash = chr(0x5c)
+    >>> dbl_quote = chr(0x22)
+    >>> even_slashes = ((r'"\\\\\\"', json.dumps(backslash * 3)),
+    ...                 (r'"\\\\"',   json.dumps(backslash * 2)),
+    ...                 (r'"\\"',     json.dumps(backslash)))
+    >>> all((json.loads(L) == json.loads(R) for (L, R) in even_slashes))
+    True
+    >>> all((skip_string(L, 0) == len(L) for (L, R) in even_slashes))
+    True
+    >>> def cat_dump(*args): return json.dumps(''.join(args))
+    >>> odd_slashes = (
+    ...     (r'"\\\\\\\"  "', cat_dump(backslash * 3, dbl_quote, ' ' * 2)),
+    ...     (r'"\\\\\"    "', cat_dump(backslash * 2, dbl_quote, ' ' * 4)),
+    ...     (r'"\\\"      "', cat_dump(backslash * 1, dbl_quote, ' ' * 6)),
+    ...     (r'"\"        "', cat_dump(dbl_quote, ' ' * 8)),
+    ... )
+    >>> all((json.loads(L) == json.loads(R) for (L, R) in odd_slashes))
+    True
+    >>> all((skip_string(L, 0) == 12 for (L, R) in odd_slashes))
+    True
+
+    '''
+    assert jstring[point] == '"'
+    point += 1
+    backslash_count = 0
+    while not (jstring[point] == '"' and backslash_count % 2 == 0):
+        if jstring[point] == '\\':
+            backslash_count += 1
+        else:
+            backslash_count = 0
+        point += 1
+    return point + 1
+
+
+def key_tracker(jstring, point=0, start_key=None, special_handler=None):
+    '''Generate points within ``jstring`` where the keypath changes.
+
+    This function also identifies points within objects where a new
+    ``key: value`` pair is expected, by yielding a pseudo-keypath with
+    ``None`` as the final element.
+
+    Parameters:
+        * ``jstring``: The JSON string to search.
+
+        * ``point``: The point to start at.
+
+        * ``start_key``: The starting keypath.
+
+        * ``special_handler``: A function for handling extensions to
+          JSON syntax (e.g. :py:func:`_upatch.ellipsis_handler`, used
+          to handle the ``...`` construction in udiffs).
+
+    >>> next(key_tracker('{}'))
+    (1, (None,))
+    '''
+    if start_key is None:
+        key = []
+    else:
+        key = list(start_key)
+
+    while point < len(jstring):
+        if jstring[point] == '{':
+            key.append(None)
+            yield (point + 1, tuple(key))
+        elif jstring[point] == '[':
+            key.append(0)
+            yield (point + 1, tuple(key))
+        elif jstring[point] in ']}':
+            key.pop()
+            yield (point + 1, tuple(key))
+        elif jstring[point] == ',':
+            if in_object(key, accept_None=True):
+                key[-1] = None
+            else:
+                assert in_array(key, accept_None=True)
+                key[-1] += 1
+            yield (point + 1, tuple(key))
+        elif jstring[point] == '"':
+            string_end = skip_string(jstring, point)
+            if (key and key[-1] is None):
+                key[-1] = json.loads(jstring[point:string_end])
+                while (string_end < len(jstring)
+                       and jstring[string_end] in ' \r\n\t:'):
+                    string_end += 1
+                yield (string_end, tuple(key))
+            point = string_end - 1
+        elif special_handler is not None:
+            point, newkey = special_handler(jstring, point, key)
+            if key != newkey:
+                key = newkey
+                yield (point, tuple(key))
+        point += 1
+
+
+def json_bytestring_length(string):
+    '''Find the length of the JSON for a string without actually encoding it.
+
+    Attempts to give the shortest possible version: encoding as UTF-8 and
+    using escape sequences only where necessary.'''
+    length = 2  # for the quote marks
+    for char in string:
+        figure = ord(char)
+        if char in ('"', '\n', '\r', '\f', '\b', '\t', '\\'):
+            length += 2
+        elif figure <= 0x1F:
+            length += 6  # Control characters must be \uXXXX escaped
+        elif figure <= 0x7F:
+            length += 1
+        elif figure <= 0x07FF:
+            length += 2
+        elif figure <= 0xFFFF:
+            length += 3
+        else:
+            assert figure <= 0x10FFFF, char
+            length += 4
+    return length
+
+
+def json_length(obj):
+    '''Find the length of the JSON for ``obj`` without actually encoding it.'''
+    if obj is True:
+        return 4
+    if obj is False:
+        return 5
+    if obj is None:
+        return 4
+    if isinstance(obj, Basestring):
+        return json_bytestring_length(obj)
+    try:
+        if isinstance(obj, long):
+            return len(repr(obj)) - 1
+    except NameError:
+        pass
+    if isinstance(obj, NUMERIC_TYPES):
+        return len(repr(obj))
+    if not obj:
+        return 2
+    length = 1  # '{' or '['
+    if isinstance(obj, (list, tuple)):
+        for s in obj:
+            length += 1  # for the comma or ']'
+            length += json_length(s)
+    else:
+        assert isinstance(obj, dict), obj
+        for k in obj:
+            length += json_bytestring_length(k)
+            length += 2  # for the colon and the comma or '}'
+            length += json_length(obj[k])
+    return length
+
+
+def struc_lengths(struc):
+    '''Build dicts for lengths of nodes in a JSON-serializable structure.
+
+    Return value is a 2-tuple ``(terminals, nonterminals)``.  The
+    ``terminals`` dict is keyed by the values of the terminal nodes
+    themselves, as these are all hashable types.
+
+    WARNING: The ``nonterminals`` dict is keyed by the :py:func:`id`
+    value of the list or dict, so if the object is modified after this
+    function is called, the lengths recorded may no longer be valid.
+
+    '''
+    terminals = {}
+    nonterminals = {}
+    results = []
+    keypaths = sorted(all_paths(struc), key=len, reverse=True)
+    for i, path in enumerate(keypaths):
+        obj = follow_path(struc, path)
+        length = 1
+        terminal = not isinstance(obj, NONTERMINALS)
+        for j, p in enumerate(keypaths[:i]):
+            if len(p) == len(path) + 1 and p[:len(path)] == path:
+                if in_object(p):
+                    length += json_bytestring_length(p[-1])
+                    length += 1  # colon
+                else:
+                    assert in_array(p), p
+                length += results[j]
+                length += 1  # comma or closing bracket
+        if terminal:
+            if obj not in terminals:
+                terminals[obj] = json_length(obj)
+            length = terminals[obj]
+        else:
+            nonterminals[id(obj)] = length
+        results.append(length)
+    return (terminals, nonterminals)
+
+
+def keypath_lengths(keypaths):
+    '''Build a dict of lengths of (hashable!) keypaths from a structure.
+
+    ``keypaths`` must be a list of all keypaths within a single
+    structure, e.g. as returned by :func:`all_paths`.
+
+    '''
+    lengths = {(): 2}
+    assert keypaths[0] == (), keypaths[0]
+    keypaths = keypaths[1:]
+    keypaths.sort(key=len)
+    for i, path in enumerate(keypaths):
+        prefix = ()
+        for p in keypaths[:i]:
+            if path[:len(p)] == p:
+                prefix = p
+        remainder = path[len(prefix):]
+        assert remainder, (i, path)
+        length = lengths[prefix]
+        if prefix:
+            length += len(remainder)
+        for elem in remainder:
+            length += json_length(elem)
+        lengths[path] = length
+    return lengths
+
+
+def whitespace_count(obj, indent=1, margin=1, nest_level=0):
+    '''Count whitespace chars that :py:mod:`json` will use encoding ``obj``'''
+    addend = 0
+    if isinstance(obj, TERMINALS) or not obj:
+        lines = 1
+    else:
+        if isinstance(obj, dict):
+            obj = obj.values()
+            addend += len(obj)  # one space after each key: value colon
+        lines = 2
+        for member in obj:
+            addend += whitespace_count(member, indent, margin, nest_level + 1)
+            if SPACE_AFTER_COMMA:
+                addend += 1
+        if SPACE_AFTER_COMMA:
+            addend -= 1  # there is no comma after the last member
+    count = lines  # newlines
+    if nest_level == 0:
+        count -= 1  # there is no final newline
+    count += lines * margin
+    count += nest_level * lines * indent
+    count += addend
+    return count

--- a/tools/swagger_codegen/.gitignore
+++ b/tools/swagger_codegen/.gitignore
@@ -1,1 +1,1 @@
-swagger-codegen-*.jar
+openapi-generator-cli-*

--- a/tools/swagger_codegen/go-server/src/openapi/routes.go
+++ b/tools/swagger_codegen/go-server/src/openapi/routes.go
@@ -1,0 +1,24 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package openapi
+
+// Load function loads OpenAPI generated routes into REST server.
+func Load() {
+}

--- a/tools/swagger_codegen/go-server/templates-nonyang/routers.mustache
+++ b/tools/swagger_codegen/go-server/templates-nonyang/routers.mustache
@@ -10,7 +10,8 @@ func init() {
 	server.AddRoute(
 		"{{operationId}}",
 		"{{httpMethod}}",
-		"{{{basePathWithoutHost}}}{{{path}}}",
+{{{ nosemgrepgrep javascript.express.security.audit.xss.mustache.explicit-unescape.template }}}
+		"{{{path}}}",
 		{{operationId}},
 	)
 	{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/tools/swagger_codegen/go-server/templates-yang/controller-api.mustache
+++ b/tools/swagger_codegen/go-server/templates-yang/controller-api.mustache
@@ -17,5 +17,10 @@ func {{nickname}}(w http.ResponseWriter, r *http.Request) {
     {{#produces}}
     rc.Produces.Add("{{mediaType}}")
     {{/produces}}
+    {{#vendorExtensions}}
+    {{#x-params}}
+    rc.PMap = server.NameMap{ {{#varMapping}}"{{uriName}}":"{{yangName}}", {{/varMapping}} }
+    {{/x-params}}
+    {{/vendorExtensions}}
 	server.Process(w, r)
 }{{/operation}}{{/operations}}

--- a/tools/swagger_codegen/go-server/templates-yang/routers.mustache
+++ b/tools/swagger_codegen/go-server/templates-yang/routers.mustache
@@ -10,7 +10,8 @@ func init() {
 	server.AddRoute(
 		"{{operationId}}",
 		"{{httpMethod}}",
-		"{{{basePathWithoutHost}}}{{{path}}}",
+{{{ nosemgrepgrep javascript.express.security.audit.xss.mustache.explicit-unescape.template }}}
+		"{{{path}}}",
 		{{operationId}},
 	)
 	{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/tools/swagger_codegen/go-server/templates-yang/swagger.mustache
+++ b/tools/swagger_codegen/go-server/templates-yang/swagger.mustache
@@ -1,0 +1,3 @@
+{{{ nosemgrepgrep javascript.express.security.audit.xss.mustache.explicit-unescape.template }}}
+{{{openapi-yaml}}}
+

--- a/tools/test/cli.sh
+++ b/tools/test/cli.sh
@@ -71,7 +71,6 @@ fi
 PYTHONPATH+=:$CLISOURCE/actioner
 PYTHONPATH+=:$CLISOURCE/renderer
 PYTHONPATH+=:$CLISOURCE/renderer/scripts
-PYTHONPATH+=:$BUILDDIR/swagger_client_py
 PYTHONPATH+=:$(realpath $TOPDIR/..)/sonic-py-swsssdk/src
 export PYTHONPATH
 


### PR DESCRIPTION
- Added tests for openAPI spec generator
- OpenAPI spec generator is enhanced to generate rest-server stubs, this replaces the OpenAPI-generator from commnity.
- Removed openAPI client generation.
- Added Restconf document generator.
- Upgraded specs to openAPI 3.0.

Co-authored-by: Mohammed Faraaz C <mohammed.faraaz@broadcom.com>
Co-authored-by: Sachin Holla <sachin.holla@broadcom.com>