### PR TITLE
TCP session does not close properly after using the curl commands.

### DIFF
--- a/rest/server/pamAuth.go
+++ b/rest/server/pamAuth.go
@@ -121,7 +121,7 @@ func PAMAuthenAndAuthor(r *http.Request, rc *RequestContext) error {
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	_, err := ssh.Dial("tcp", "127.0.0.1:22", config)
+	client, err := ssh.Dial("tcp", "127.0.0.1:22", config)
 	if err != nil {
 		glog.Infof("[%s] Failed to authenticate; %v", rc.ID, err)
 		return httpError(http.StatusUnauthorized, "")
@@ -134,6 +134,7 @@ func PAMAuthenAndAuthor(r *http.Request, rc *RequestContext) error {
 		glog.Warningf("[%s] Not an admin; cannot allow %s", rc.ID, r.Method)
 		return httpError(http.StatusForbidden, "Not an admin user")
 	}
+	defer client.Close()
 
 	glog.Infof("[%s] Authorization passed", rc.ID)
 	return nil


### PR DESCRIPTION
If the REST server enables user authentication, it connects from the container using 127.0.0.1 to the host to retrieve the user and password. However, the TCP connection is not properly closed after the retrieval. So I add a command to ensure the connection is closed properly.