### PR TITLE
[CLI] Require explicit CA for remote Python REST connections

### DIFF
--- a/CLI/actioner/README_cli_client.md
+++ b/CLI/actioner/README_cli_client.md
@@ -11,6 +11,10 @@ import cli_client as cc
 api = cc.ApiClient()
 ```
 
+The client connects to `https://localhost` by default. To connect to a non-loopback REST server, set
+`REST_API_ROOT` to the server URL and `REST_API_CA_CERT` to a readable PEM CA certificate file. The
+client does not use the system CA store for non-loopback endpoints.
+
 Create a path object for target REST resource. It accepts parameterized path template and parameter
 values. Path template is similar to the template used by swagger. Parameter values will be URL-encoded
 and substituted in the template to get REST resource path.

--- a/CLI/actioner/cli_client.py
+++ b/CLI/actioner/cli_client.py
@@ -17,6 +17,7 @@
 #                                                                              #
 ################################################################################
 
+import ipaddress
 import os
 import json
 import warnings
@@ -33,11 +34,14 @@ def _is_loopback_endpoint(url):
         hostname = urlparse(url).hostname
     except ValueError:
         return False
-    return hostname is not None and hostname.lower() in (
-        'localhost',
-        '127.0.0.1',
-        '::1',
-    )
+    if hostname is None:
+        return False
+    if hostname.lower() == 'localhost':
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
 
 
 class ApiClient(object):

--- a/CLI/actioner/cli_client.py
+++ b/CLI/actioner/cli_client.py
@@ -29,6 +29,9 @@ from collections import OrderedDict
 from cli_log import log_info, log_warning
 
 
+REST_API_CA_CERT = 'REST_API_CA_CERT'
+
+
 def _is_loopback_endpoint(url):
     try:
         hostname = urlparse(url).hostname
@@ -66,8 +69,19 @@ class ApiClient(object):
                 req_headers['Content-Type'] = 'application/yang-data+json'
             body = json.dumps(data)
 
+        verify = False
+        if not _is_loopback_endpoint(url):
+            verify = os.getenv(REST_API_CA_CERT)
+            if not verify:
+                msg = '%Error: REST_API_CA_CERT must be set for a remote Management REST Server'
+                log_info("cli_client certificate configuration error: {}", msg)
+                return ApiClient.__new_error_response(msg)
+            if not os.path.isfile(verify) or not os.access(verify, os.R_OK):
+                msg = '%Error: REST_API_CA_CERT must identify a readable CA certificate file'
+                log_info("cli_client certificate configuration error: {}", msg)
+                return ApiClient.__new_error_response(msg)
+
         try:
-            verify = not _is_loopback_endpoint(url)
             with warnings.catch_warnings():
                 if not verify:
                     warnings.simplefilter('ignore', InsecureRequestWarning)

--- a/CLI/actioner/cli_client.py
+++ b/CLI/actioner/cli_client.py
@@ -19,14 +19,25 @@
 
 import os
 import json
-import urllib3
+import warnings
 import requests
 from requests.structures import CaseInsensitiveDict
-from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import quote, urlparse
+from urllib3.exceptions import InsecureRequestWarning
 from collections import OrderedDict
 from cli_log import log_info, log_warning
 
-urllib3.disable_warnings()
+
+def _is_loopback_endpoint(url):
+    try:
+        hostname = urlparse(url).hostname
+    except ValueError:
+        return False
+    return hostname is not None and hostname.lower() in (
+        'localhost',
+        '127.0.0.1',
+        '::1',
+    )
 
 
 class ApiClient(object):
@@ -52,13 +63,17 @@ class ApiClient(object):
             body = json.dumps(data)
 
         try:
-            r = ApiClient.__session.request(
-                method,
-                url,
-                headers=req_headers,
-                data=body,
-                params=query,
-                verify=False)
+            verify = not _is_loopback_endpoint(url)
+            with warnings.catch_warnings():
+                if not verify:
+                    warnings.simplefilter('ignore', InsecureRequestWarning)
+                r = ApiClient.__session.request(
+                    method,
+                    url,
+                    headers=req_headers,
+                    data=body,
+                    params=query,
+                    verify=verify)
 
             return Response(r, response_type)
 

--- a/CLI/tests/test_cli_client.py
+++ b/CLI/tests/test_cli_client.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import unittest
+import warnings
+from unittest import mock
+
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+
+
+ACTIONER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'actioner'))
+sys.path.insert(0, ACTIONER_DIR)
+
+import cli_client
+
+
+def _response():
+    response = requests.Response()
+    response.status_code = 200
+    response._content = b''
+    return response
+
+
+class ApiClientCertificateVerificationTest(unittest.TestCase):
+
+    def test_loopback_endpoint_detection(self):
+        loopback_urls = (
+            'https://localhost',
+            'https://localhost:443',
+            'https://127.0.0.1',
+            'https://127.0.0.1:8443',
+            'https://[::1]',
+            'https://[::1]:8443',
+        )
+        remote_urls = (
+            'https://rest.example.com',
+            'https://localhost.example.com',
+            'https://192.0.2.1',
+            'https://[::1',
+        )
+
+        for url in loopback_urls:
+            with self.subTest(url=url):
+                self.assertTrue(cli_client._is_loopback_endpoint(url))
+
+        for url in remote_urls:
+            with self.subTest(url=url):
+                self.assertFalse(cli_client._is_loopback_endpoint(url))
+
+    def test_loopback_request_skips_certificate_verification(self):
+        with mock.patch.object(
+                cli_client.ApiClient,
+                '_ApiClient__api_root',
+                'https://127.0.0.1'):
+            with mock.patch.object(
+                    cli_client.ApiClient,
+                    '_ApiClient__session') as session:
+                session.request.return_value = _response()
+
+                cli_client.ApiClient().get('/restconf/data')
+
+                self.assertFalse(session.request.call_args.kwargs['verify'])
+
+    def test_remote_request_verifies_server_certificate(self):
+        with mock.patch.object(
+                cli_client.ApiClient,
+                '_ApiClient__api_root',
+                'https://rest.example.com'):
+            with mock.patch.object(
+                    cli_client.ApiClient,
+                    '_ApiClient__session') as session:
+                session.request.return_value = _response()
+
+                cli_client.ApiClient().get('/restconf/data')
+
+                self.assertTrue(session.request.call_args.kwargs['verify'])
+
+    def test_loopback_warning_suppression_is_scoped_to_request(self):
+        def request_with_warning(*args, **kwargs):
+            warnings.warn('loopback request', InsecureRequestWarning)
+            return _response()
+
+        with mock.patch.object(
+                cli_client.ApiClient,
+                '_ApiClient__api_root',
+                'https://localhost'):
+            with mock.patch.object(
+                    cli_client.ApiClient,
+                    '_ApiClient__session') as session:
+                session.request.side_effect = request_with_warning
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter('error', InsecureRequestWarning)
+                    cli_client.ApiClient().get('/restconf/data')
+                    with self.assertRaises(InsecureRequestWarning):
+                        warnings.warn('outside request', InsecureRequestWarning)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/CLI/tests/test_cli_client.py
+++ b/CLI/tests/test_cli_client.py
@@ -63,19 +63,83 @@ class ApiClientCertificateVerificationTest(unittest.TestCase):
 
                 self.assertFalse(session.request.call_args.kwargs['verify'])
 
-    def test_remote_request_verifies_server_certificate(self):
+    def test_remote_request_uses_configured_ca_certificate(self):
         with mock.patch.object(
                 cli_client.ApiClient,
                 '_ApiClient__api_root',
                 'https://rest.example.com'):
-            with mock.patch.object(
-                    cli_client.ApiClient,
-                    '_ApiClient__session') as session:
-                session.request.return_value = _response()
+            with mock.patch.dict(
+                    os.environ,
+                    {cli_client.REST_API_CA_CERT: '/etc/sonic/rest-ca.pem'}):
+                with mock.patch('cli_client.os.path.isfile', return_value=True):
+                    with mock.patch('cli_client.os.access', return_value=True):
+                        with mock.patch.object(
+                                cli_client.ApiClient,
+                                '_ApiClient__session') as session:
+                            session.request.return_value = _response()
 
-                cli_client.ApiClient().get('/restconf/data')
+                            cli_client.ApiClient().get('/restconf/data')
 
-                self.assertTrue(session.request.call_args.kwargs['verify'])
+                            self.assertEqual(
+                                '/etc/sonic/rest-ca.pem',
+                                session.request.call_args.kwargs['verify'])
+
+    def test_remote_request_requires_ca_certificate(self):
+        with mock.patch.object(
+                cli_client.ApiClient,
+                '_ApiClient__api_root',
+                'https://rest.example.com'):
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with mock.patch.object(
+                        cli_client.ApiClient,
+                        '_ApiClient__session') as session:
+
+                    response = cli_client.ApiClient().get('/restconf/data')
+
+                    session.request.assert_not_called()
+                    self.assertEqual(
+                        '%Error: REST_API_CA_CERT must be set for a remote Management REST Server',
+                        response.content['ietf-restconf:errors']['error'][0]['error-message'])
+
+    def test_remote_request_does_not_use_requests_ca_bundle(self):
+        with mock.patch.object(
+                cli_client.ApiClient,
+                '_ApiClient__api_root',
+                'https://rest.example.com'):
+            with mock.patch.dict(
+                    os.environ,
+                    {'REQUESTS_CA_BUNDLE': '/etc/ssl/certs/ca-certificates.crt'},
+                    clear=True):
+                with mock.patch.object(
+                        cli_client.ApiClient,
+                        '_ApiClient__session') as session:
+
+                    response = cli_client.ApiClient().get('/restconf/data')
+
+                    session.request.assert_not_called()
+                    self.assertEqual(
+                        '%Error: REST_API_CA_CERT must be set for a remote Management REST Server',
+                        response.content['ietf-restconf:errors']['error'][0]['error-message'])
+
+    def test_remote_request_rejects_unreadable_ca_certificate(self):
+        with mock.patch.object(
+                cli_client.ApiClient,
+                '_ApiClient__api_root',
+                'https://rest.example.com'):
+            with mock.patch.dict(
+                    os.environ,
+                    {cli_client.REST_API_CA_CERT: '/etc/sonic/missing.pem'}):
+                with mock.patch('cli_client.os.path.isfile', return_value=False):
+                    with mock.patch.object(
+                            cli_client.ApiClient,
+                            '_ApiClient__session') as session:
+
+                        response = cli_client.ApiClient().get('/restconf/data')
+
+                        session.request.assert_not_called()
+                        self.assertEqual(
+                            '%Error: REST_API_CA_CERT must identify a readable CA certificate file',
+                            response.content['ietf-restconf:errors']['error'][0]['error-message'])
 
     def test_loopback_warning_suppression_is_scoped_to_request(self):
         def request_with_warning(*args, **kwargs):

--- a/CLI/tests/test_cli_client.py
+++ b/CLI/tests/test_cli_client.py
@@ -29,6 +29,8 @@ class ApiClientCertificateVerificationTest(unittest.TestCase):
             'https://localhost:443',
             'https://127.0.0.1',
             'https://127.0.0.1:8443',
+            'https://127.0.0.2',
+            'https://127.255.255.254',
             'https://[::1]',
             'https://[::1]:8443',
         )


### PR DESCRIPTION
## Why

The Python CLI actioner may connect to either the default local REST server or a configured remote endpoint. Remote connections should use a CA certificate selected specifically for that REST server while preserving the existing local workflow.

## What

- Require `REST_API_CA_CERT` to identify a readable PEM CA certificate file for every non-loopback REST endpoint.
- Pass the configured CA path directly to Requests without falling back to Requests-specific or system CA bundles.
- Preserve the current behavior for `localhost`, IPv4 loopback addresses (`127.0.0.0/8`), and IPv6 loopback (`::1`).
- Limit certificate-warning suppression to individual loopback requests.
- Document the remote endpoint configuration and add focused unit coverage.

## How to verify

- `python3 -m unittest discover -s CLI/tests -p 'test_*.py' -v` — 7 tests passed.
- `python3 -m py_compile CLI/actioner/cli_client.py CLI/tests/test_cli_client.py`
- `git diff --check origin/master...HEAD`

VS validation on `vlab-01`:

1. Built `target/debs/trixie/sonic-mgmt-framework_1.0-01_amd64.deb` and installed it in the `mgmt-framework` container.
2. Confirmed the default loopback REST endpoint remained reachable.
3. Confirmed that setting only `REQUESTS_CA_BUNDLE` did not provide a fallback for a remote endpoint.
4. Confirmed that a missing or unreadable `REST_API_CA_CERT` was rejected before the request.
5. Configured `REST_API_CA_CERT` with the test endpoint's CA and confirmed that the request succeeded.

Results:

```text
endpoint_classification=PASS
local_loopback_request=PASS status=404
requests_ca_bundle_fallback_rejected=PASS
invalid_explicit_ca_rejected=PASS
explicit_ca_accepted=PASS status=200
```
