### PR TITLE
[CLI] Require explicit CA for remote C++ REST connections

### DIFF
--- a/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.cpp
+++ b/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.cpp
@@ -187,10 +187,11 @@ static int _init_curl() {
                 return 1;
             }
 
+            /* ca_cert was validated non-null by is_readable_ca_file(). */
             if (curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L) != CURLE_OK ||
                 curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L) != CURLE_OK ||
                 curl_easy_setopt(curl, CURLOPT_CAINFO, ca_cert) != CURLE_OK ||
-                curl_easy_setopt(curl, CURLOPT_CAPATH, "") != CURLE_OK) {
+                curl_easy_setopt(curl, CURLOPT_CAPATH, NULL) != CURLE_OK) {
                 REST_CLIENT_INIT_ERROR = "failed to configure REST server certificate verification";
                 syslog(LOG_ERR, "clish_restcl: %s", REST_CLIENT_INIT_ERROR.c_str());
                 curl_easy_cleanup(curl);

--- a/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.cpp
+++ b/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.cpp
@@ -39,7 +39,10 @@ extern "C" {
 
 #include <string>
 
+#include "rest_tls.h"
+
 std::string REST_API_ROOT;
+std::string REST_CLIENT_INIT_ERROR;
 
 typedef struct {
     int size;
@@ -169,9 +172,32 @@ static int _init_curl() {
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
 
-    if (REST_API_ROOT.find("https://") == 0) {
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    if (rest_tls::is_https_url(REST_API_ROOT)) {
+        if (rest_tls::is_loopback_url(REST_API_ROOT)) {
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        } else {
+            const char *ca_cert = getenv("REST_API_CA_CERT");
+            if (!rest_tls::is_readable_ca_file(ca_cert)) {
+                REST_CLIENT_INIT_ERROR =
+                    "REST_API_CA_CERT must name a readable CA certificate file for a remote HTTPS REST server";
+                syslog(LOG_ERR, "clish_restcl: %s", REST_CLIENT_INIT_ERROR.c_str());
+                curl_easy_cleanup(curl);
+                curl = NULL;
+                return 1;
+            }
+
+            if (curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L) != CURLE_OK ||
+                curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L) != CURLE_OK ||
+                curl_easy_setopt(curl, CURLOPT_CAINFO, ca_cert) != CURLE_OK ||
+                curl_easy_setopt(curl, CURLOPT_CAPATH, "") != CURLE_OK) {
+                REST_CLIENT_INIT_ERROR = "failed to configure REST server certificate verification";
+                syslog(LOG_ERR, "clish_restcl: %s", REST_CLIENT_INIT_ERROR.c_str());
+                curl_easy_cleanup(curl);
+                curl = NULL;
+                return 1;
+            }
+        }
     } else {
         curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, "/var/run/rest-local.sock");
     }
@@ -183,10 +209,11 @@ void rest_client_init() {
     char *root = getenv("REST_API_ROOT");
 
     REST_API_ROOT.assign(root ? root : "http://localhost");
+    REST_CLIENT_INIT_ERROR.clear();
 
-    _init_curl();
-
-    rest_set_curl_headers(true);
+    if (_init_curl() == 0) {
+        rest_set_curl_headers(true);
+    }
 }
 
 int rest_token_fetch(int *interval) {
@@ -195,7 +222,8 @@ int rest_token_fetch(int *interval) {
     std::string url;
 
     if (!curl) {
-        syslog(LOG_WARNING, "curl handle is not yet initialized.");
+        syslog(LOG_WARNING, "curl handle is not initialized: %s",
+                REST_CLIENT_INIT_ERROR.empty() ? "unknown error" : REST_CLIENT_INIT_ERROR.c_str());
         return 1;
     }
     
@@ -356,8 +384,14 @@ int rest_cl(char *cmd, const char *buff)
             }
         }
     } else {
-        lub_dump_printf("%%Error: Could not connect to Management REST Server\n");
-        syslog(LOG_WARNING, "Couldn't initialize curl handle");
+        if (REST_CLIENT_INIT_ERROR.empty()) {
+            lub_dump_printf("%%Error: Could not connect to Management REST Server\n");
+            syslog(LOG_WARNING, "Couldn't initialize curl handle");
+        } else {
+            lub_dump_printf("%%Error: %s\n", REST_CLIENT_INIT_ERROR.c_str());
+            syslog(LOG_WARNING, "Couldn't initialize curl handle: %s",
+                    REST_CLIENT_INIT_ERROR.c_str());
+        }
     }
 
     return ret_code;

--- a/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h
+++ b/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h
@@ -78,11 +78,17 @@ inline bool is_loopback_url(const std::string& url)
     }
 
     struct in6_addr ipv6;
-    return inet_pton(AF_INET6, host.c_str(), &ipv6) == 1 && IN6_IS_ADDR_LOOPBACK(&ipv6);
+    if (inet_pton(AF_INET6, host.c_str(), &ipv6) != 1) {
+        return false;
+    }
+
+    return IN6_IS_ADDR_LOOPBACK(&ipv6) ||
+           (IN6_IS_ADDR_V4MAPPED(&ipv6) && ipv6.s6_addr[12] == 127);
 }
 
 inline bool is_readable_ca_file(const char *path)
 {
+    /* The path must remain operator-controlled between this check and libcurl's open. */
     struct stat file_stat;
     return path && path[0] != '\0' && stat(path, &file_stat) == 0 &&
            S_ISREG(file_stat.st_mode) && access(path, R_OK) == 0;

--- a/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h
+++ b/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h
@@ -1,5 +1,4 @@
-#ifndef CLISH_REST_TLS_H
-#define CLISH_REST_TLS_H
+#pragma once
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -95,5 +94,3 @@ inline bool is_readable_ca_file(const char *path)
 }
 
 }  // namespace rest_tls
-
-#endif

--- a/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h
+++ b/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h
@@ -1,0 +1,93 @@
+#ifndef CLISH_REST_TLS_H
+#define CLISH_REST_TLS_H
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace rest_tls {
+
+inline bool is_https_url(const std::string& url)
+{
+    static const char scheme[] = "https://";
+    return url.size() >= sizeof(scheme) - 1 &&
+           strncasecmp(url.c_str(), scheme, sizeof(scheme) - 1) == 0;
+}
+
+inline bool get_url_host(const std::string& url, std::string& host)
+{
+    const std::string::size_type scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) {
+        return false;
+    }
+
+    const std::string::size_type authority_start = scheme_end + 3;
+    const std::string::size_type authority_end = url.find_first_of("/?#", authority_start);
+    std::string authority = url.substr(authority_start, authority_end - authority_start);
+    if (authority.empty()) {
+        return false;
+    }
+
+    const std::string::size_type userinfo_end = authority.rfind('@');
+    if (userinfo_end != std::string::npos) {
+        authority.erase(0, userinfo_end + 1);
+    }
+
+    if (authority.empty()) {
+        return false;
+    }
+
+    if (authority[0] == '[') {
+        const std::string::size_type bracket_end = authority.find(']');
+        if (bracket_end == std::string::npos) {
+            return false;
+        }
+        if (bracket_end + 1 < authority.size() && authority[bracket_end + 1] != ':') {
+            return false;
+        }
+        host = authority.substr(1, bracket_end - 1);
+    } else {
+        const std::string::size_type port_start = authority.find(':');
+        if (port_start != std::string::npos && authority.find(':', port_start + 1) != std::string::npos) {
+            return false;
+        }
+        host = authority.substr(0, port_start);
+    }
+
+    return !host.empty();
+}
+
+inline bool is_loopback_url(const std::string& url)
+{
+    std::string host;
+    if (!get_url_host(url, host)) {
+        return false;
+    }
+
+    if (strcasecmp(host.c_str(), "localhost") == 0) {
+        return true;
+    }
+
+    struct in_addr ipv4;
+    if (inet_pton(AF_INET, host.c_str(), &ipv4) == 1) {
+        return (ntohl(ipv4.s_addr) >> 24) == 127;
+    }
+
+    struct in6_addr ipv6;
+    return inet_pton(AF_INET6, host.c_str(), &ipv6) == 1 && IN6_IS_ADDR_LOOPBACK(&ipv6);
+}
+
+inline bool is_readable_ca_file(const char *path)
+{
+    struct stat file_stat;
+    return path && path[0] != '\0' && stat(path, &file_stat) == 0 &&
+           S_ISREG(file_stat.st_mode) && access(path, R_OK) == 0;
+}
+
+}  // namespace rest_tls
+
+#endif

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,5 +138,6 @@ stages:
     - script: |
         # KLISH sanity
         pushd sonic-mgmt-framework
+        tools/test/rest-tls.sh
         tools/test/cli.sh -c 'exit'
       displayName: "KLISH Sanity Test"

--- a/tools/test/rest-tls.cpp
+++ b/tools/test/rest-tls.cpp
@@ -1,0 +1,64 @@
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+
+#include "../../CLI/klish/patches/klish-2.1.4/plugins/clish/rest_tls.h"
+
+static int failures = 0;
+
+static void expect_loopback(const char *url, bool expected)
+{
+    const bool actual = rest_tls::is_loopback_url(url);
+    if (actual != expected) {
+        std::fprintf(stderr, "is_loopback_url(%s): expected %d, got %d\n",
+                     url, expected, actual);
+        ++failures;
+    }
+}
+
+static void expect_readable_ca(const char *path, bool expected)
+{
+    const bool actual = rest_tls::is_readable_ca_file(path);
+    if (actual != expected) {
+        std::fprintf(stderr, "is_readable_ca_file(%s): expected %d, got %d\n",
+                     path ? path : "null", expected, actual);
+        ++failures;
+    }
+}
+
+int main()
+{
+    expect_loopback("https://localhost", true);
+    expect_loopback("HTTPS://LOCALHOST:443/restconf", true);
+    expect_loopback("https://127.0.0.1", true);
+    expect_loopback("https://127.255.255.254:8443", true);
+    expect_loopback("https://[::1]", true);
+    expect_loopback("https://[::1]:8443/restconf", true);
+
+    expect_loopback("https://localhost.example.com", false);
+    expect_loopback("https://127.0.0.1.example.com", false);
+    expect_loopback("https://128.0.0.1", false);
+    expect_loopback("https://[::2]", false);
+    expect_loopback("https://example.com", false);
+    expect_loopback("https://localhost@remote.example", false);
+    expect_loopback("https://[::1.example.com", false);
+    expect_loopback("not-a-url", false);
+
+    char ca_path[] = "/tmp/rest-tls-ca-XXXXXX";
+    const int ca_fd = mkstemp(ca_path);
+    if (ca_fd == -1) {
+        std::perror("mkstemp");
+        return EXIT_FAILURE;
+    }
+    close(ca_fd);
+
+    expect_readable_ca(ca_path, true);
+    expect_readable_ca(NULL, false);
+    expect_readable_ca("", false);
+    expect_readable_ca("/path/that/does/not/exist", false);
+    expect_readable_ca("/tmp", false);
+
+    unlink(ca_path);
+    return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tools/test/rest-tls.cpp
+++ b/tools/test/rest-tls.cpp
@@ -35,11 +35,14 @@ int main()
     expect_loopback("https://127.255.255.254:8443", true);
     expect_loopback("https://[::1]", true);
     expect_loopback("https://[::1]:8443/restconf", true);
+    expect_loopback("https://[::ffff:127.0.0.1]", true);
+    expect_loopback("https://[::ffff:127.255.255.254]:8443", true);
 
     expect_loopback("https://localhost.example.com", false);
     expect_loopback("https://127.0.0.1.example.com", false);
     expect_loopback("https://128.0.0.1", false);
     expect_loopback("https://[::2]", false);
+    expect_loopback("https://[::ffff:128.0.0.1]", false);
     expect_loopback("https://example.com", false);
     expect_loopback("https://localhost@remote.example", false);
     expect_loopback("https://[::1.example.com", false);

--- a/tools/test/rest-tls.sh
+++ b/tools/test/rest-tls.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+TEST_DIR=$(dirname "$(readlink -f "$0")")
+TEST_BIN=$(mktemp /tmp/rest-tls-test-XXXXXX)
+trap 'rm -f "$TEST_BIN"' EXIT
+
+g++ -std=c++11 -Wall -Wextra -Werror "$TEST_DIR/rest-tls.cpp" -o "$TEST_BIN"
+"$TEST_BIN"

--- a/tools/test/rest-tls.sh
+++ b/tools/test/rest-tls.sh
@@ -6,5 +6,5 @@ TEST_DIR=$(dirname "$(readlink -f "$0")")
 TEST_BIN=$(mktemp /tmp/rest-tls-test-XXXXXX)
 trap 'rm -f "$TEST_BIN"' EXIT
 
-g++ -std=c++11 -Wall -Wextra -Werror "$TEST_DIR/rest-tls.cpp" -o "$TEST_BIN"
+"${CXX:-g++}" -std=c++11 -Wall -Wextra -Werror "$TEST_DIR/rest-tls.cpp" -o "$TEST_BIN"
 "$TEST_BIN"


### PR DESCRIPTION
## Why

The C++ klish REST client may connect to either the default local REST server or a configured remote HTTPS endpoint. Remote connections should use a CA certificate selected specifically for that REST server while preserving the existing local workflow.

## What

- Require `REST_API_CA_CERT` to identify a readable CA certificate file for every non-loopback HTTPS REST endpoint.
- Configure libcurl to verify the peer certificate and hostname using the selected CA file without falling back to its compiled-in CA directory.
- Preserve the current behavior for `localhost`, IPv4 loopback addresses (`127.0.0.0/8`), and IPv6 loopback (`::1`).
- Report a clear initialization error when the required CA configuration is missing or invalid.
- Add focused coverage for accepted and rejected endpoint classification and CA path validation.

This is the C++ client counterpart to #166. Operator-facing CLI configuration can be added separately.

## How to verify

Run `tools/test/rest-tls.sh` to verify:

- `localhost`, IPv4 `127.0.0.0/8`, IPv6 `::1`, and IPv4-mapped `127.0.0.0/8` endpoints are recognized as loopback.
- Remote, misleading, and malformed endpoint names are not recognized as loopback.
- Readable CA files are accepted, while missing paths, empty paths, and directories are rejected.

All tests passed.